### PR TITLE
docs: align Phase 3 docs (DATABASE, MODULES, FLOWS) with current wallet implementation

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,58 +2,79 @@
 
 This document serves as one of the three documents that makes up the single source of truth of this project, along with [ARCHITECTURE.md](ARCHITECTURE.md) and [PRD.md](PRD.md). Here its defined the *database* schema of the project, *where* and *how* the data is stored and how the entities interact with each other to accomplish the business logic defined in the PRD.
 
+The **implemented schema** matches **Phase 3** (Django ORM): Django’s built-in user table plus `wallet_account` and `wallet_transaction` (see `wallet/models.py` and migrations).
+
 ## Entity Relationship Diagram (ERD)
 
 ```mermaid
 erDiagram
-    USERS ||--o{ TRANSACTIONS : "performs"
-    
-    USERS {
+    USER ||--|| ACCOUNT : "OneToOne"
+    "TRANSACTION" }o--|| USER : "from_user"
+    "TRANSACTION" }o--|| USER : "to_user"
+
+    USER {
         int id PK
-        string username
+        string username UK
         string email
-        string password_hash
-        decimal balance
+        string password
     }
 
-    TRANSACTIONS {
+    ACCOUNT {
         int id PK
-        int user_id FK
-        string type
+        int user_id FK, UK
+        decimal balance
+        datetime created_at
+    }
+
+    "TRANSACTION" {
+        int id PK
+        int from_user_id FK "nullable"
+        int to_user_id FK "nullable"
         decimal amount
-        string related_user
-        timestamp created_at
+        string type
+        text description
+        datetime created_at
+        decimal balance_after "nullable"
     }
 ```
 
 ## Data Model Explanation
 
-The current design follows a simplified relational model focused on financial integrity and traceability, perfectly suited for the Phase 2 requirements.
+The design separates **identity** (Django `User`), **current funds** (`Account`), and the **ledger** (`Transaction`). Financial rules are enforced with ORM validators and PostgreSQL `CHECK` constraints (via Django `CheckConstraint`).
 
 ### Entities and Relationships
 
-#### 1. USERS Entity
-This is the core of the wallet system. It contains the user's identification data and the current total funds available to the user.
-- **id (PK)**: Unique identifier for each user.
-- **username / email**: Identification data, marked as `UNIQUE` to prevent duplicates.
-- **password_hash**: Stores encrypted passwords (never plain text) for security.
-- **balance**: The current total funds available to the user.
+#### 1. User (`django.contrib.auth.models.User`)
 
-#### 2. TRANSACTIONS Entity
-Records every movement of money.
-- **id (PK)**: Unique identifier for the transaction.
-- **user_id (FK)**: Links the transaction to a specific user.
-- **type**: Categorizes the movement (e.g., `deposit`, `transfer`).
-- **amount**: The monetary value of the transaction. Uses `decimal` types to ensure precision and avoid floating-point errors.
-- **related_user**: Stores the counterpart's name for transfers, providing quick context without complex joins.
-- **created_at**: Automatic timestamp for audit trails.
+Standard Django authentication user. Holds username, email, password hash, and related auth fields. **Balance is not stored on `User`.**
+
+#### 2. Account (`wallet.Account`)
+
+One row per user wallet balance.
+
+- **user**: `OneToOneField` to `User` (`related_name='account'`). Cascade delete removes the account with the user.
+- **balance**: `DecimalField(max_digits=12, decimal_places=2)`, default `0.00`, with `MinValueValidator(0)` and DB check **`balance >= 0`** (`balance_non_negative`).
+- **created_at**: Set automatically on create.
+
+**Provisioning:** A `post_save` signal on `User` calls `Account.objects.get_or_create(user=instance)` when a user is created, so new users always get an `Account`.
+
+#### 3. Transaction (`wallet.Transaction`)
+
+Append-only style ledger for deposits and transfers (and reserved type `withdrawal` in choices).
+
+- **from_user** / **to_user**: Optional `ForeignKey` to `User` (`SET_NULL` on delete), `related_name='sent_transactions'` / `'received_transactions'`. Deposits set `to_user` only; transfers set both.
+- **amount**: `DecimalField` with `MinValueValidator(0.01)` and DB check **`amount > 0`** (`amount_positive`).
+- **type**: `CharField` with choices `deposit`, `transfer`, `withdrawal`.
+- **description**: Optional text (e.g. transfer memo).
+- **created_at**: Automatic timestamp.
+- **balance_after**: Optional; after deposits/transfers from the web UI it stores the **sender’s** account balance after the operation where applicable.
 
 ### Key Design Principles
 
-- **One-to-Many Relationship (`||--o{`)**: A single user can have multiple transactions, but each transaction belongs to exactly one user.
-- **Data Integrity**: The schema includes database-level constraints (e.g., `balance >= 0` and `amount > 0`) to enforce business rules at the storage layer.
-- **Scalability**: While simple, this two-table structure provides a solid foundation for future features like categories or contact lists.
+- **Separation of concerns**: Balances live on `Account`; `Transaction` rows provide history and audit context.
+- **Integrity**: Non-negative balance and strictly positive amounts are enforced at validation and database level.
+- **Evolution**: Optional FKs and `withdrawal` allow future flows without breaking existing rows.
 
 ---
 
-*Last updated: 16 February, 2026 - Phase 2 - Sprint 16: Database Design & Setup*
+*Last updated: 23 March, 2026 — Phase 3 (Django wallet); schema aligned with `wallet/models.py`.*

--- a/docs/FLOWS.md
+++ b/docs/FLOWS.md
@@ -1,8 +1,10 @@
 # System Flows (Phase 3)
 
-This document contains the visual representation of the main business processes in the Django-based architecture using Mermaid sequence diagrams.
+This document contains the visual representation of the main business processes in the Django-based architecture using Mermaid sequence diagrams. Paths match `config/urls.py` and behaviour in `wallet/views.py`.
 
 ## 1. User Authentication Flow (Session-Based)
+
+Login uses Django’s built-in views under `/accounts/` (e.g. `POST /accounts/login/`). On success, `LOGIN_REDIRECT_URL` sends the user to the named route **`menu`** (`/menu/`).
 
 ```mermaid
 sequenceDiagram
@@ -16,52 +18,110 @@ sequenceDiagram
     Django->>Django: Validate CSRF (Layer 2)
     Django->>DB: Query user by username
     DB-->>Django: User data (hashed password)
-    Django->>Django: Verify PBKDF2 hash
+    Django->>Django: Verify password (configured hashers, e.g. PBKDF2)
     alt Success
         Django->>Django: Create Session
-        Django-->>Browser: Set Session Cookie / Redirect to Dashboard
-        Browser->>User: Show Dashboard
+        Django-->>Browser: Set Session Cookie / Redirect to /menu/
+        Browser->>User: Show menu (dashboard)
     else Failure
         Django-->>Browser: Show error message (invalid credentials)
         Browser->>User: Show error
     end
 ```
 
-## 2. Peer-to-Peer Transfer Flow (Layered Integrity)
+## 2. Deposit Flow
 
 ```mermaid
 sequenceDiagram
     participant User
     participant Browser
-    participant View as Django View
-    participant Form as Django Form
-    participant Model as Django Model
+    participant View as wallet.views.deposit
+    participant Form as DepositForm
+    participant Model as Account / Transaction
+    participant DB as PostgreSQL
+
+    User->>Browser: Enters amount
+    Browser->>Browser: Validate HTML5 (Layer 1)
+    Browser->>View: POST /deposit/ (with CSRF)
+    View->>Form: is_valid()
+    alt Form Valid
+        View->>View: transaction.atomic()
+        View->>Model: add to balance, save Account
+        View->>Model: Transaction.objects.create(to_user, type=deposit, balance_after, ...)
+        Model->>DB: UPDATE wallet_account, INSERT wallet_transaction
+        DB-->>View: Commit
+        View->>View: messages.success
+        View-->>Browser: Redirect to menu
+        Browser->>User: Flash success + menu
+    else Form Invalid
+        View-->>Browser: Re-render deposit.html with errors
+        Browser->>User: Show validation errors
+    end
+```
+
+## 3. Peer-to-Peer Transfer Flow (Layered Integrity)
+
+Template: `wallet/sendmoney.html`. URL path: **`/transfer/`**.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant View as wallet.views.transfer
+    participant Form as TransferForm
+    participant Model as Account / Transaction
     participant DB as PostgreSQL
 
     User->>Browser: Selects recipient & amount
     Browser->>Browser: Validate HTML5 (Layer 1: min, required)
     Browser->>View: POST /transfer/ (with CSRF)
-    View->>Form: is_valid() (Layer 3: clean_amount)
+    View->>Form: is_valid() (Layer 3)
     alt Form Valid
         View->>View: BEGIN transaction.atomic (Layer 4)
-        View->>Model: update balance / create transaction
+        View->>Model: decrement sender balance, increment receiver balance
+        View->>Model: Transaction.objects.create(from_user, to_user, type=transfer, balance_after, ...)
         Model->>Model: Run Validators (Layer 5: MinValueValidator)
         Model->>DB: SQL UPDATE / INSERT
-        DB->>DB: Check Constraints (Layer 6: balance >= 0)
+        DB->>DB: Check Constraints (Layer 6: balance >= 0, amount > 0)
         alt DB Success
             DB-->>View: Commit
-            View-->>Browser: 200 OK / Success Message
-            Browser->>User: Show success & update UI
-        else DB Failure (IntegrityError)
+            View->>View: messages.success
+            View-->>Browser: Redirect to menu
+            Browser->>User: Show success on menu
+        else DB Failure (e.g. IntegrityError)
             DB-->>View: Rollback
-            View-->>Browser: Show error message
+            View-->>Browser: Error message via messages / template
         end
     else Form Invalid
-        Form-->>Browser: Show validation errors
+        View-->>Browser: Re-render sendmoney.html with errors
         Browser->>User: Show error message
     end
 ```
 
+## 4. Transaction History Flow
+
+`TransactionHistoryView`: `GET /history/` (optional query `?filter=income` or `?filter=expense`). Queryset: transactions where the user is `from_user` OR `to_user`, ordered by `-created_at`, paginated (`paginate_by = 10`).
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant View as TransactionHistoryView
+    participant DB as PostgreSQL
+
+    User->>Browser: Open history (optional filter)
+    Browser->>View: GET /history/?filter=...
+    View->>View: LoginRequiredMixin
+    View->>DB: SELECT transactions for user (with optional filter)
+    DB-->>View: Page of rows
+    View-->>Browser: Render transactions.html (page_obj, current_filter)
+    Browser->>User: Show paginated ledger
+```
+
+## 5. Root URL
+
+`GET /` triggers a redirect to the named route **`menu`** (`/menu/`), implemented in `config/urls.py`.
+
 ---
 
-*Last updated: 11 March, 2026 - Phase 3 - Sprint 26: Cleanup and Local Deployment*
+*Last updated: 23 March, 2026 — Phase 3; aligned with `config/urls.py` and `wallet/views.py`.*

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -6,45 +6,70 @@ This document describes the responsibilities and dependencies of the system modu
 
 ```text
 proggy-wallet/
-├── core/                 # Global Django settings and URL routing
-├── wallet/               # Main application (Models, Views, Forms, Tests)
-│   ├── migrations/       # Database version control
-│   ├── admin.py          # Admin interface configuration
-│   ├── forms.py          # Form validation logic (Layer 3)
-│   ├── models.py         # Data models and constraints (Layers 5 & 6)
-│   ├── tests.py          # Integration and unit tests
-│   └── views.py          # Business logic and orchestration (Layer 4)
-├── templates/            # UI Views (Django Template Language)
-│   ├── base.html         # Master layout
-│   ├── registration/     # Auth templates (Login)
-│   └── *.html            # Dashboard, Deposit, Transfer views
-├── static/               # Static assets (CSS, JS, Images)
-├── docs/                 # Comprehensive documentation and ADRs
-├── scripts/              # Utility scripts for development
-├── .env                  # Environment variables (DB, SECRET_KEY)
-├── docker-compose.yml    # PostgreSQL container configuration
-├── pyproject.toml        # Project configuration & dependencies (uv)
-└── manage.py             # Django management entry point
+├── config/               # Django project: settings, root URLconf, WSGI/ASGI
+│   ├── settings.py
+│   ├── urls.py
+│   ├── wsgi.py
+│   └── asgi.py
+├── wallet/               # Wallet app (models, views, forms, tests)
+│   ├── migrations/
+│   ├── templates/
+│   │   ├── base.html
+│   │   ├── registration/
+│   │   │   └── login.html
+│   │   └── wallet/
+│   │       ├── menu.html
+│   │       ├── deposit.html
+│   │       ├── sendmoney.html   # served by URL name transfer → path transfer/
+│   │       └── transactions.html
+│   ├── admin.py
+│   ├── apps.py
+│   ├── forms.py
+│   ├── models.py
+│   ├── tests.py
+│   └── views.py
+├── templates/            # Optional project-level templates (e.g. index.html)
+├── static/               # STATICFILES_DIRS in settings (project static assets)
+├── docs/
+├── scripts/
+├── .env
+├── docker-compose.yml
+├── pyproject.toml
+└── manage.py
 ```
 
-## Core Application (`wallet/`)
+**Template loading:** `config/settings.py` sets `TEMPLATES['DIRS']` to `[]` and uses `APP_DIRS: True`, so app templates are resolved from `wallet/templates/` (and other installed apps).
 
-- **`models.py`**: **(Data Layer)** Defines the relational schema using Django ORM. Implements **Layer 5 (Validators)** and **Layer 6 (Database Constraints)** to ensure financial data integrity.
-- **`views.py`**: **(Logic Layer)** Orchestrates business flows. Implements **Layer 4 (Business Logic)** using `transaction.atomic()` to guarantee atomicity in transfers and deposits.
-- **`forms.py`**: **(Validation Layer)** Handles server-side sanitization and business rule validation (**Layer 3**). Ensures clean data entry before reaching the models.
-- **`admin.py`**: Provides a secure interface for managing users, accounts, and transactions.
-- **`tests.py`**: Comprehensive suite of integration tests verifying the 6-layer security strategy.
+## Wallet application (`wallet/`)
 
-## Global Configuration (`core/`)
+- **`models.py`**: **(Data layer)** `Account`, `Transaction`, and `User` provisioning signal. Validators (**layer 5**) and `CheckConstraint` (**layer 6**) match `wallet/models.py`.
+- **`views.py`**: **(Logic layer)** `menu`, `deposit`, `transfer` (function views), and `TransactionHistoryView` (class-based list with pagination and query filters). Uses `transaction.atomic()` for deposits and transfers.
+- **`forms.py`**: **(Validation layer)** `DepositForm`, `TransferForm` — server-side rules before writes.
+- **`admin.py`**: Admin registration for wallet models.
+- **`tests.py`**: Tests for wallet behaviour.
 
-- **`settings.py`**: Centralized configuration for the Django framework, including database connections, installed apps, and security middleware (**Layer 2**).
-- **`urls.py`**: Global URL routing, connecting web requests to the appropriate views in the `wallet` app.
+## Global configuration (`config/`)
 
-## Presentation Layer (`templates/` & `static/`)
+- **`settings.py`**: Database (`DB_URL` via `django-environ`), `INSTALLED_APPS` (includes `wallet`), middleware, `STATIC_URL` / `STATICFILES_DIRS`, auth redirects (`LOGIN_REDIRECT_URL = 'menu'`, `LOGOUT_REDIRECT_URL = 'login'`), custom `PASSWORD_HASHERS` list.
+- **`urls.py`**: Root routes (see below).
 
-- **DTL Templates**: Responsive UI built with Bootstrap 5 and Django Template Language. Implements **Layer 1 (Frontend UX)** with native HTML5 validations.
-- **Static Assets**: Centralized CSS and JavaScript files served by Django.
+### URL map (root `config/urls.py`)
+
+| Path | View / handler |
+| --- | --- |
+| `admin/` | Django admin |
+| `accounts/` | `django.contrib.auth.urls` (login, logout, password reset, etc.) |
+| `menu/` | `wallet.views.menu` |
+| `deposit/` | `wallet.views.deposit` |
+| `transfer/` | `wallet.views.transfer` → template `wallet/sendmoney.html` |
+| `history/` | `wallet.views.TransactionHistoryView` → `wallet/transactions.html` |
+| `''` | Redirect to named route `menu` |
+
+## Presentation layer
+
+- **DTL**: Bootstrap-oriented pages under `wallet/templates/`; login under `wallet/templates/registration/` for `auth` URLs.
+- **Static files**: Served from the project `static/` directory per `STATICFILES_DIRS`.
 
 ---
 
-*Last updated: 11 March, 2026 - Phase 3 - Sprint 26: Cleanup and Local Deployment*
+*Last updated: 23 March, 2026 — Phase 3; aligned with `config/` and `wallet/`.*


### PR DESCRIPTION
## Summary
Updates the three “source of truth” docs so they match the shipped Phase 3 Django app (`wallet` + `config`), removing references to the old two-table Phase 2 sketch and incorrect `core/` paths.

## Changes
- **DATABASE.md** — Schema: `Account` 1:1 `User`, `Transaction` with `from_user`/`to_user`, checks, provisioning signal.
- **MODULES.md** — Real tree (`config/`, `wallet/templates/`), `APP_DIRS`, full URL table, `transfer` → `sendmoney.html`.
- **FLOWS.md** — Deposit flow, transfer redirect + messages, history + filters, root → `menu`, login → `menu`.

## How to verify
- Compare with `wallet/models.py`, `config/urls.py`, `wallet/views.py`.