### PR TITLE
docs: Django-only architecture docs, Phase 3.1 plan, avatar ADR, DEVLOG

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,106 +3,94 @@
 This document serves as one of the three documents that makes up the single source of truth of this project, along with [PRD.md](PRD.md) and [DATABASE.md](DATABASE.md). Here its defined the *architecture* of the project, *how* the components interact with each other and how the data flows to accomplish the business logic defined in the PRD.
 
 ## 1. Overview
-**Proggy Wallet** is a virtual wallet application designed to manage personal finances through a simple and secure web interface. The system enables users to perform core banking operations (deposits, transfers, and transaction history tracking) within a dynamic, real-time environment.
 
-The architecture follows a **Decoupled Client-Server model**, ensuring that the User Interface (UI) and the Business Logic can evolve independently.
+**Proggy Wallet** is a virtual wallet application designed to manage personal finances through a simple and secure web interface. The system enables users to perform core banking operations (deposits, transfers, and transaction history tracking) within a session-based, server-rendered environment.
+
+The architecture follows a **classic Django web application** model: the browser exchanges HTML form posts and GET navigations with the server; the server is the **single source of truth** for balances and ledger data.
 
 ## 2. System Components
 
 ### 2.1 Frontend (The Client)
-*   **Responsibility:** Data presentation, user input capture, and local session management.
-*   **State Management:** The client is "stateless" regarding financial data. It does not calculate balances; it only requests and displays data provided by the server.
-*   **Technologies:** `HTML5`, `Bootstrap 5` (Responsive UI), and `jQuery` (DOM manipulation and UX effects).
+
+* **Responsibility:** Data presentation, user input capture, and session cookie handling.
+* **State Management:** The client does not compute authoritative balances; it displays values returned by the server.
+* **Technologies:** `HTML5`, `Bootstrap 5` (responsive UI), and `jQuery` (DOM manipulation and UX effects).
 
 ### 2.2 Backend (The Server)
-*   **Responsibility:** The "Single Source of Truth." It handles data validation, transaction processing, and persistence.
-*   **Interface:** It exposes a RESTful API using FastAPI.
-*   **Technologies:** `Python 3.12+`, `FastAPI`, and `Pydantic` (Schema validation).
 
-## 3. Data Flow (HTTP Request/Response Cycle)
+* **Responsibility:** Authentication, validation, business orchestration, and persistence.
+* **Interface:** **Django** — URL routing, views (function- and class-based), Django Forms, Django ORM, and Django Templates.
+* **Technologies:** `Python 3.12+`, **Django**, **PostgreSQL**.
 
-Communication between components follows an asynchronous pattern:
+### 2.3 Planned apps (Phase 3.1)
 
-1.  **Trigger:** The user performs an action (e.g., clicking "Transfer").
-2.  **Request:** The Frontend emits an asynchronous `fetch` request, sending a JSON object in the `body` and specifying `Content-Type: application/json` in the headers.
-3.  **Validation:** FastAPI receives the request and utilizes **Pydantic Models** to ensure data types and constraints (e.g., positive amounts) are met before execution.
-4.  **Business Logic:** Python modules process the operation via the Service Layer.
-5.  **Persistence:** Data is persisted in PostgreSQL via the Repository layer.
-6.  **Response:** The Backend returns an HTTP status code (e.g., 200: OK, 400: Bad Request) and a JSON response object.
-7.  **UI Update:** The Frontend receives the response and updates the DOM dynamically without a page reload.
+* **`profiles`:** `UserProfile` linked to `User`; profile edit and **avatar** uploads. Media storage strategy: [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+* **`reports`:** Read-only **insights** over `wallet` models (aggregations, charts, CSV export). Does not introduce a second ledger; writes remain in `wallet`.
 
-## 4. Backend Internal Architecture (Layered Design)
+## 3. Data Flow (Request / Response)
 
-The backend follows a **Layered Architecture** to ensure separation of concerns. This allows us to change the database engine or the API framework with minimal impact on business logic.
+Typical cycle for wallet actions:
 
-### 4.1 Layer Map & Dependencies
-Dependencies always point **inwards**. Outer layers (API) depend on inner layers (Services/Repositories), but the Domain (Entities) remains pure and independent.
+1. **Trigger:** The user submits a form or opens a protected page.
+2. **Request:** The browser sends HTTP **GET** or **POST** (with **CSRF** token on posts) to Django.
+3. **Routing:** `config.urls` dispatches to the appropriate view in `wallet`, `profiles`, or `reports`.
+4. **Auth:** `LoginRequiredMixin` or `@login_required` ensures identity where required.
+5. **Validation:** Django **Forms** (and model `full_clean()` / validators) enforce input rules.
+6. **Business logic:** Views orchestrate changes; financial mutations use **`transaction.atomic()`** where multiple rows must succeed or fail together.
+7. **Persistence:** Django ORM persists to PostgreSQL.
+8. **Response:** Redirect with **messages** framework and/or re-render template with context (errors, lists, aggregates).
+
+## 4. Backend Structure (Django-oriented)
+
+Dependencies point **inward**: URLconf → views → (forms / models) → ORM → database. Optional **service modules** inside an app (e.g. `reports/services.py`) may encapsulate query logic without bypassing the ORM.
 
 ```text
-    [ API Layer (app.py) ]
+    [ config/urls.py ]
              │
              ▼
-    [ Service Layer (services.py, auth.py) ]
+    [ App views + forms (wallet | profiles | reports) ]
              │
              ▼
-    [ Repository Layer (repository.py) ]
+    [ Django ORM (models, constraints, signals) ]
              │
              ▼
-    [ Infrastructure Layer (PostgreSQL) ]
-             │
-             └───────────▶ [ Domain Entities (entities.py) ]
-                                      │
-                                      ▼
-                           [ Schemas (models.py) ]
+    [ PostgreSQL ]
 ```
 
-| Layer | Component | Responsibility | Dependencies |
-| :--- | :--- | :--- | :--- |
-| **API** | `app.py` | HTTP Entry point, routing, and JSON responses. | Services, Models |
-| **Service** | `services.py`, `auth.py` | **Orchestration**: Business flows (Transfers) and **Identity Logic** (Authentication/Login). | Repositories, Entities, Models |
-| **Repository** | `repository.py` | **Data Access**: Handles SQL queries and maps DB rows to Domain Entities. | Models, Entities |
-| **Domain** | `entities.py` | **Core Logic**: Pure business rules (e.g., "how an account calculates its state"). | Models |
-| **Schemas** | `models.py` | **Data Contracts**: Pydantic models for validation and DTOs. | (None) |
+| Layer | Responsibility |
+| :--- | :--- |
+| **URLconf** | Map paths to views; include per-app `urls.py` as the project grows. |
+| **Views** | HTTP entry, permission checks, orchestration, response type. |
+| **Forms** | Request validation and user-facing field errors. |
+| **Models** | Schema, invariants, `CheckConstraint`, relations. |
+| **Templates** | Render HTML; no business calculations for money. |
 
-### 4.2 Why this Layer Map? (Justification)
-This specific design (API -> Service -> Repository -> DB) is the industry standard for robust applications because:
-1. **Decoupling**: The `Service Layer` doesn't know *how* data is saved (SQL or CSV), it only knows *what* it wants to do.
-2. **Testability**: We can test the `Service Layer` by "mocking" the `Repository` without needing a real database.
-3. **Maintainability**: If we move from PostgreSQL to another DB, we only change the `Repository` layer. The `Service` and `API` layers remain untouched.
-4. **Consistency**: The `Repository` ensures that everything coming out of the database is converted into a valid `Entity` or `Model` before reaching the rest of the app.
+### 4.1 Error handling
 
-### 4.3 Error Handling Policy
-
-To prevent generic "Internal Server Errors", the following policy is applied across layers:
-
-#### Exception Mapping
-| Layer | Action | Example |
-| :--- | :--- | :--- |
-| **Domain** | Raise semantic Python exceptions | `raise ValueError("Insufficient funds")` |
-| **Repository** | Raise data-related exceptions | `raise DBError("Connection failed")` |
-| **API** | Catch and convert to `HTTPException` | `raise HTTPException(status_code=400, detail=...)` |
-
----
+| Situation | Typical handling |
+| :--- | :--- |
+| Invalid form | Re-render template with form errors. |
+| Business rule violation | Message or error string; avoid silent failure. |
+| Missing resource | `Http404` where appropriate. |
 
 ## 5. Technology Stack
 
 | Technology | Rationale |
 | :--- | :--- |
-| **FastAPI** | High performance (ASGI), automatic Pydantic validation, and instant OpenAPI documentation. |
-| **PostgreSQL** | **(Phase 2 Upgrade)** Provides ACID compliance, relational integrity, and professional scalability. |
-| **Pydantic** | Strict schema enforcement and data validation (Fail-Fast principle). |
-| **uv** | Next-generation package manager for reproducible environments. |
-| **Docker** | Used to containerize the PostgreSQL instance for consistent development environments. |
-
----
+| **Django** | Integrated ORM, auth, forms, admin, and migration workflow for a cohesive monolith. |
+| **PostgreSQL** | ACID compliance, relational integrity, and scalable querying. |
+| **uv** | Reproducible environments and fast dependency management. |
+| **Docker** (Phase 4) | Consistent dev/prod parity and deployment artifacts. |
 
 ## 6. ADRs (Architecture Decision Records)
 
-| ID | Decision | Status | Key Justification (Summary) |
+| ID | Decision | Status | Key justification (summary) |
 | :--- | :--- | :--- | :--- |
-| [ADR-01](adr/01-use-fastapi-for-backend-integration.md) | **FastAPI** | Accepted | Quick and asynchronous integration with automatic validation. |
-| [ADR-02](adr/02-use-csv-for-initial-persistence.md) | **CSV/JSON** | Superado | Useful for rapid prototyping in Phase 1. Replaced by SQL in Phase 2. |
-| [ADR-03](adr/03-use-postgresql-for-persistent-storage.md) | **PostgreSQL** | Accepted | Needed for data integrity, ACID transactions, and professional scalability. |
+| [ADR-01](adr/01-use-fastapi-for-backend-integration.md) | FastAPI (Phase 1 history) | **Superseded** | Historical; product now uses Django only. |
+| [ADR-02](adr/02-use-csv-for-initial-persistence.md) | **CSV/JSON** | Superseded | Phase 1 prototyping; replaced by SQL/ORM. |
+| [ADR-03](adr/03-use-postgresql-for-persistent-storage.md) | **PostgreSQL** | Accepted | Integrity, ACID, relational model. |
+| [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md) | **Avatar storage** | Accepted | Local media in dev; durable object storage (or persistent volume) in cloud prod. |
 
 ---
-*Last Updated: 13 February, 2026 - Phase 2 - Sprint 16: Database Design & Setup*
+
+*Last updated: 23 March, 2026 — Django architecture; Phase 3.1 apps documented.*

--- a/docs/CLASS_DIAGRAM.md
+++ b/docs/CLASS_DIAGRAM.md
@@ -1,80 +1,78 @@
 # Class Diagram & Design Decisions
 
-This document outlines the Object-Oriented Programming (OOP) architecture for **Proggy Wallet** introduced in Phase 2. The transition from procedural scripts to a class-based structure aims to improve maintainability, scalability, and data integrity.
+This document describes the **domain-oriented** structure of Proggy Wallet aligned with the **Django** implementation (Phase 3) and the **planned** Phase 3.1 models. It complements [DATABASE.md](DATABASE.md) and `wallet/models.py`.
 
-## Class Diagram
+## Class diagram (conceptual / ORM-aligned)
 
 ```mermaid
 classDiagram
     class User {
-        +String username
-        +String email
-        +String hashed_password
-        +Account account
-        +login(password) bool
-        +update_profile(email, full_name)
+        <<django.contrib.auth>>
+        +username
+        +email
+        +password hash
+    }
+
+    class UserProfile {
+        <<profiles Phase 3.1>>
+        +OneToOne user
+        +avatar optional
+        +bio optional
     }
 
     class Account {
-        +String owner_username
-        +Float balance
-        +List~Transaction~ transactions
-        +deposit(amount, source) Transaction
-        +transfer(target_account, amount) Transaction
-        +get_history() List~Transaction~
+        <<wallet.Account>>
+        +OneToOne user
+        +Decimal balance
+        +created_at
     }
 
     class Transaction {
-        +DateTime date
-        +String type
-        +Float amount
-        +Float balance_after
-        +String description
-        +to_dict() dict
+        <<wallet.Transaction>>
+        +FK from_user optional
+        +FK to_user optional
+        +Decimal amount
+        +type
+        +description
+        +created_at
+        +balance_after optional
     }
 
-    class TransactionManager {
-        <<Service>>
-        +execute_transfer(from_account, to_account, amount)
-        +record_to_persistence(transaction)
-    }
-
-    User "1" -- "1" Account : has
-    Account "1" -- "*" Transaction : contains
-    TransactionManager ..> Account : manages
-    TransactionManager ..> Transaction : creates
+    User "1" -- "1" Account : account
+    User "1" -- "0..1" UserProfile : profile
+    User "1" -- "*" Transaction : sent_transactions
+    User "1" -- "*" Transaction : received_transactions
 ```
 
-## Design Decisions
+**Phase 3.1 (reports):** Aggregation and export logic may live in plain Python functions or a small **`reports.services`** module; it is not a second ledger. Diagrams can add `<<service>>` helpers later if useful.
+
+## Design decisions
 
 ### 1. Decoupling User and Account
-*   **Decision:** The `User` entity handles identity and authentication, while the `Account` entity manages financial state.
-*   **Rationale:** This follows the **Single Responsibility Principle (SRP)**. A user represents a person, whereas an account represents a financial container. This separation allows a single user to potentially own multiple accounts (e.g., Savings, Checking) in future iterations without refactoring the core identity logic.
 
-### 2. Encapsulated Logic in Account
-*   **Decision:** Core financial operations like `deposit()` and `transfer()` are methods within the `Account` class.
-*   **Rationale:** This ensures that the account "protects" its own state. The account is responsible for validating its balance before allowing a withdrawal or transfer, preventing invalid financial states at the object level.
+* **Decision:** Django `User` holds identity; `wallet.Account` holds the spendable balance (`OneToOne`).
+* **Rationale:** Single responsibility. Matches the shipped ORM and migrations.
 
-### 3. Immutable Transaction Records
-*   **Decision:** The `Transaction` class acts as a read-only snapshot of a financial event.
-*   **Rationale:** In financial systems, audit trails must be immutable. Once a transaction is created, it should never be modified. This ensures the integrity of the transaction history and simplifies balance reconciliation.
+### 2. Transaction as ledger row
 
-### 4. TransactionManager as a Service Layer
-*   **Decision:** Introduced a `TransactionManager` to handle complex operations involving multiple entities.
-*   **Rationale:** A transfer involves two different accounts. Placing this logic inside one of the accounts would create tight coupling. The `TransactionManager` acts as a coordinator (Service Pattern) that ensures the operation is atomic: if the deduction from the sender fails, the credit to the receiver never happens.
+* **Decision:** `wallet.Transaction` records movements with optional `from_user` / `to_user` and positive `amount`.
+* **Rationale:** Audit trail and history UI; constraints at DB and model level prevent invalid amounts.
 
-### 5. Type Safety with Pydantic (Integration)
-*   **Decision:** All class attributes will be validated using Pydantic models before object instantiation.
-*   **Rationale:** This provides a "fail-fast" mechanism. By enforcing strict types and constraints (e.g., `amount > 0`) at the entry point, we ensure that the logic within our classes always operates on clean, valid data.
+### 3. UserProfile extension (Phase 3.1)
 
-### 6. Data Transfer Objects (DTO) Pattern
-*   **Decision:** Split models into `Base`, `Create`, and `Final` versions (e.g., `UserBase`, `UserCreate`, `User`).
-*   **Rationale:** Data takes different shapes depending on the application stage.
-    *   **Base:** Contains common fields (e.g., `username`, `email`) to follow the **DRY (Don't Repeat Yourself)** principle.
-    *   **Create:** Used only during registration/creation; it includes sensitive fields like `password` but lacks system-generated fields like `id` or `balance`.
-    *   **Final/Out:** Used for responses and internal logic; it excludes sensitive data like passwords for security while including stateful data like `balance`.
-    *   **Benefit:** This separation prevents critical security leaks, such as accidentally exposing password hashes through the API.
+* **Decision:** Separate **`UserProfile`** model with **`OneToOneField`** to `User` for display fields and avatar.
+* **Rationale:** Avoid overriding Django’s `User` table; keeps auth upgrades straightforward. Avatar storage follows [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+
+### 4. Validation in Django, not a parallel API layer
+
+* **Decision:** Incoming data is validated with **Django Forms** and **model validators** / `CheckConstraint`.
+* **Rationale:** The product is a server-rendered Django app; one validation path reduces drift.
+
+### 5. Reports read the wallet schema
+
+* **Decision:** First version of **`reports`** performs **read-only** ORM queries over `Transaction` (and `Account` if needed for context).
+* **Rationale:** One source of truth for money; reporting cannot bypass wallet invariants.
 
 ---
 
-*Last updated: 16 February, 2026 - Phase 2 - Sprint 16: Database Design & Setup*
+*Last updated: 23 March, 2026 — Django / Phase 3 + planned `UserProfile`.*

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,13 +2,16 @@
 
 This document serves as one of the three documents that makes up the single source of truth of this project, along with [ARCHITECTURE.md](ARCHITECTURE.md) and [PRD.md](PRD.md). Here its defined the *database* schema of the project, *where* and *how* the data is stored and how the entities interact with each other to accomplish the business logic defined in the PRD.
 
-The **implemented schema** matches **Phase 3** (Django ORM): Django’s built-in user table plus `wallet_account` and `wallet_transaction` (see `wallet/models.py` and migrations).
+The **implemented** wallet schema matches **Phase 3** (Django ORM): Django’s built-in user table plus `wallet_account` and `wallet_transaction` (see `wallet/models.py` and migrations).
+
+**Phase 3.1** adds **`profiles_userprofile`** (planned name: model **`UserProfile`**) as described below.
 
 ## Entity Relationship Diagram (ERD)
 
 ```mermaid
 erDiagram
     USER ||--|| ACCOUNT : "OneToOne"
+    USER ||--o| USERPROFILE : "OneToOne planned"
     "TRANSACTION" }o--|| USER : "from_user"
     "TRANSACTION" }o--|| USER : "to_user"
 
@@ -17,6 +20,13 @@ erDiagram
         string username UK
         string email
         string password
+    }
+
+    USERPROFILE {
+        int id PK
+        int user_id FK, UK
+        string avatar
+        text bio
     }
 
     ACCOUNT {
@@ -37,6 +47,8 @@ erDiagram
         decimal balance_after "nullable"
     }
 ```
+
+> **Note:** `USERPROFILE` is **planned** for Phase 3.1; exact optional columns (e.g. `display_name`) follow the `profiles` app implementation. The **`reports`** app is expected to add **no new tables** in the first iteration (read-only queries over `wallet`).
 
 ## Data Model Explanation
 
@@ -69,6 +81,12 @@ Append-only style ledger for deposits and transfers (and reserved type `withdraw
 - **created_at**: Automatic timestamp.
 - **balance_after**: Optional; after deposits/transfers from the web UI it stores the **sender’s** account balance after the operation where applicable.
 
+#### 4. UserProfile (`profiles.UserProfile`) — Phase 3.1 (planned)
+
+- **user**: `OneToOneField` to `User` (primary association for extended profile data).
+- **avatar**: Optional image field; file storage per [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+- Additional display or preference fields as required by the PRD and forms (migrations will be the canonical list).
+
 ### Key Design Principles
 
 - **Separation of concerns**: Balances live on `Account`; `Transaction` rows provide history and audit context.
@@ -77,4 +95,4 @@ Append-only style ledger for deposits and transfers (and reserved type `withdraw
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3 (Django wallet); schema aligned with `wallet/models.py`.*
+*Last updated: 23 March, 2026 — Phase 3 implemented; `UserProfile` planned Phase 3.1.*

--- a/docs/FLOWS.md
+++ b/docs/FLOWS.md
@@ -124,4 +124,74 @@ sequenceDiagram
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3; aligned with `config/urls.py` and `wallet/views.py`.*
+## 6. Planned flows — Phase 3.1 (`profiles`, `reports`)
+
+The following are **not yet implemented**; paths are illustrative (see [MODULES.md](MODULES.md)).
+
+### 6.1 View / edit profile and avatar
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant View as profiles.views
+    participant Form as ProfileForm
+    participant Storage as FileSystemStorage or S3
+    participant DB as PostgreSQL
+
+    User->>Browser: Open profile / edit form
+    Browser->>View: GET /profile/ (example path)
+    View->>DB: Load User + UserProfile
+    View-->>Browser: Render form
+    User->>Browser: Submit profile / optional image
+    Browser->>View: POST /profile/ (CSRF, multipart if file)
+    View->>Form: is_valid()
+    alt Valid
+        View->>DB: Save User fields + UserProfile
+        opt Avatar present
+            View->>Storage: Save under MEDIA per ADR-04
+        end
+        View-->>Browser: Redirect + success message
+    else Invalid
+        View-->>Browser: Re-render with errors
+    end
+```
+
+### 6.2 Insights dashboard (read-only)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant View as reports.views
+    participant ORM as Django ORM
+    participant DB as PostgreSQL
+
+    User->>Browser: Open insights page
+    Browser->>View: GET /insights/ (example path)
+    View->>View: LoginRequiredMixin
+    View->>ORM: Aggregate/filter wallet.Transaction for request.user
+    ORM->>DB: SELECT (read-only)
+    DB-->>View: Rows / aggregates
+    View-->>Browser: Render reports template (charts/tables)
+```
+
+### 6.3 CSV export (user-scoped)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant View as reports.views
+    participant DB as PostgreSQL
+
+    User->>Browser: Request export (link or POST)
+    Browser->>View: GET export endpoint with same scope as UI filters
+    View->>View: LoginRequiredMixin, build queryset for current user only
+    View->>DB: Read transactions (or summary rows)
+    View-->>Browser: text/csv response (attachment)
+```
+
+---
+
+*Last updated: 23 March, 2026 — Phase 3 implemented; Phase 3.1 planned.*

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -28,6 +28,23 @@ proggy-wallet/
 │   ├── models.py
 │   ├── tests.py
 │   └── views.py
+├── profiles/             # Phase 3.1 — UserProfile, avatar, edit profile (planned)
+│   ├── migrations/
+│   ├── templates/
+│   │   └── profiles/
+│   ├── models.py         # UserProfile (OneToOne User)
+│   ├── forms.py
+│   ├── views.py
+│   ├── urls.py
+│   └── tests.py
+├── reports/              # Phase 3.1 — insights, charts, CSV export (planned)
+│   ├── migrations/       # Often empty at v1 (read-only from wallet)
+│   ├── templates/
+│   │   └── reports/
+│   ├── services.py       # Optional: aggregation helpers
+│   ├── views.py
+│   ├── urls.py
+│   └── tests.py
 ├── templates/            # Optional project-level templates (e.g. index.html)
 ├── static/               # STATICFILES_DIRS in settings (project static assets)
 ├── docs/
@@ -38,7 +55,15 @@ proggy-wallet/
 └── manage.py
 ```
 
-**Template loading:** `config/settings.py` sets `TEMPLATES['DIRS']` to `[]` and uses `APP_DIRS: True`, so app templates are resolved from `wallet/templates/` (and other installed apps).
+**Template loading:** `config/settings.py` sets `TEMPLATES['DIRS']` to `[]` and uses `APP_DIRS: True`, so app templates are resolved from each installed app’s `templates/` package (e.g. `wallet`, then `profiles`, `reports` once added).
+
+### App dependencies (Phase 3.1 target)
+
+| App | Depends on | Notes |
+| --- | --- | --- |
+| `wallet` | `django.contrib.auth` | Core ledger and accounts. |
+| `profiles` | `auth.User` | `UserProfile` one-to-one; media files via `MEDIA_*` settings. |
+| `reports` | `wallet` (read-only) | Query `Transaction` / `Account`; no duplicate write path for money movement. |
 
 ## Wallet application (`wallet/`)
 
@@ -50,7 +75,7 @@ proggy-wallet/
 
 ## Global configuration (`config/`)
 
-- **`settings.py`**: Database (`DB_URL` via `django-environ`), `INSTALLED_APPS` (includes `wallet`), middleware, `STATIC_URL` / `STATICFILES_DIRS`, auth redirects (`LOGIN_REDIRECT_URL = 'menu'`, `LOGOUT_REDIRECT_URL = 'login'`), custom `PASSWORD_HASHERS` list.
+- **`settings.py`**: Database (`DB_URL` via `django-environ`), `INSTALLED_APPS` (includes `wallet`; will include `profiles`, `reports`), middleware, `STATIC_URL` / `STATICFILES_DIRS`, **`MEDIA_URL` / `MEDIA_ROOT`** when avatars ship (Phase 3.1), auth redirects (`LOGIN_REDIRECT_URL = 'menu'`, `LOGOUT_REDIRECT_URL = 'login'`), custom `PASSWORD_HASHERS` list.
 - **`urls.py`**: Root routes (see below).
 
 ### URL map (root `config/urls.py`)
@@ -65,6 +90,16 @@ proggy-wallet/
 | `history/` | `wallet.views.TransactionHistoryView` → `wallet/transactions.html` |
 | `''` | Redirect to named route `menu` |
 
+### Planned URLs (Phase 3.1 — wire in `config/urls.py` when implemented)
+
+| Path (illustrative) | App | Purpose |
+| --- | --- | --- |
+| `profile/` or `profiles/` | `profiles` | View/edit `UserProfile`, avatar upload |
+| `insights/` or `reports/` | `reports` | Dashboard of aggregates / charts |
+| `reports/export.csv` (example) | `reports` | User-scoped CSV download |
+
+Exact path prefixes and names should match `profiles/urls.py` and `reports/urls.py` once created.
+
 ## Presentation layer
 
 - **DTL**: Bootstrap-oriented pages under `wallet/templates/`; login under `wallet/templates/registration/` for `auth` URLs.
@@ -72,4 +107,4 @@ proggy-wallet/
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3; aligned with `config/` and `wallet/`.*
+*Last updated: 23 March, 2026 — Phase 3 shipped; Phase 3.1 (`profiles`, `reports`) planned structure.*

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,7 +6,7 @@ This document serves as one of the three documents that makes up the single sour
 
 This project is developed as a self-authored solution based on real-world fintech industry challenges.
 * **Core Base**: The initial Functional Requirements (MVP) were based on a dynamic frontend and Python data management.
-* **Evolution**: The project has evolved from a flat-file prototype (Phase 1) to a robust relational architecture (Phase 2), with a roadmap towards a full-stack Django enterprise application (Phase 3 & 4).
+* **Evolution**: The project evolved from a flat-file prototype (Phase 1) to PostgreSQL and structured domain concepts (Phase 2), then to a **Django** web application (Phase 3). **Phase 3.1** adds user profile and reporting capabilities on top of the wallet core.
 
 ## **2. Project Vision**
 
@@ -18,42 +18,59 @@ To develop a reference architecture for a digital wallet application. The primar
 |---|---|---|
 | **Frontend**       | **HTML5 / Bootstrap 5** | Semantic structure and responsive design (Mobile-first). |
 |                    | **JavaScript / jQuery** | DOM manipulation and client-side logic. |
-| **Backend**        | **Python 3.12+ / FastAPI** | Business logic, API endpoints, and data processing. |
-| **Database**       | **PostgreSQL 18** | Relational data persistence and integrity. |
-| **Quality (QA)**   | **Ruff / Pytest** | Strict linting and unit testing suite. |
+| **Backend**        | **Python 3.12+ / Django** | Server-side logic, routing, ORM, forms, session auth, admin. |
+| **Database**       | **PostgreSQL** | Relational data persistence and integrity. |
+| **Quality (QA)**   | **Ruff / Pytest** | Strict linting and automated tests. |
 | **Management**     | **uv** | High-performance dependency and project manager. |
-| **Validation**     | **Pydantic** | Data Schema definition and runtime validation. |
-| **Infrastructure** | **Docker** | Containerization for consistent environments. |
+| **Validation**     | **Django Forms / ORM** | Server-side validation and model constraints. |
+| **Infrastructure** | **Docker** (Phase 4) | Containerization for consistent environments and deployment. |
 
-## **4. Functional Requirements (Phase 2 - Robustness)**
+## **4. Functional Requirements**
 
-**A. Frontend Module**
-1. **Login**: Secure authentication flow.
-2. **Dashboard**: Real-time balance display and navigation.
-3. **Deposits**: Form to add funds with immediate database update.
-4. **Transfers**: Peer-to-peer money transfers with balance validation.
-5. **History**: Detailed transaction ledger fetched from PostgreSQL.
+### **4.1 Phase 3 — Wallet core (delivered)**
 
-**B. Backend & Data Module**
-1. **API Layer (FastAPI)**: RESTful endpoints to connect Frontend and Database.
-2. **Relational Persistence**: Full migration from JSON/CSV to PostgreSQL.
-3. **Financial Logic**: Atomic transactions to ensure data consistency during transfers.
-4. **Type Validation**: Strict Pydantic models for all incoming and outgoing data.
+**A. Authenticated web experience**
+1. **Login / logout**: Django session-based authentication.
+2. **Menu / dashboard**: Entry point after login; navigation to wallet actions.
+3. **Deposits**: Form to add funds with immediate persistence on the user’s `Account`.
+4. **Transfers**: Peer-to-peer transfers with balance validation and atomic updates.
+5. **History**: Transaction ledger scoped to the current user, with filtering and pagination.
+
+**B. Data and integrity**
+1. **Single source of truth** for balances on `Account`; immutable-style ledger on `Transaction` as implemented in Django.
+2. **Financial logic**: Atomic operations for transfers and deposits (database transaction boundaries).
+3. **Constraints**: Non-negative balances, strictly positive transaction amounts, enforced in ORM and DB where defined.
+
+### **4.2 Phase 3.1 — Profiles & insights (planned)**
+
+**A. `profiles` app**
+1. **UserProfile**: Extended data linked **one-to-one** to Django `User` (e.g. display-oriented fields, optional bio).
+2. **Avatar**: Optional profile image upload with documented limits (format/size); storage per [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+3. **Edit flow**: Authenticated user can view and update their own profile (and avatar).
+
+**B. `reports` app (insights)**
+1. **Summaries**: Aggregated views over the user’s wallet activity (e.g. by period, by movement type), using existing `wallet` models only (**read-only**).
+2. **Visualization**: Charts or summary cards as appropriate (implementation detail).
+3. **Export**: Minimum **CSV** export for a clearly defined user-scoped dataset (e.g. filtered transactions or summary table — exact export shape to be fixed in implementation and MODULES/FLOWS).
+
+### **4.3 Phase 5 — Out of current MVP**
+
+Features listed under **Phase 5** in [ROADMAP.md](ROADMAP.md) (preferences, notifications, support, budgets, etc.) are **not** part of Phase 3.1 unless explicitly pulled into a future milestone.
 
 ## **5. Non-Functional Requirements**
 
-- **Data Integrity**: Database-level constraints (CHECK, UNIQUE, FK) to prevent invalid financial states.
-- **Security**: Password hashing (BCrypt/Argon2) and environment variable management (.env).
-- **Modularity**: Clean separation between API routes, business logic, and database repositories.
-- **Performance**: Efficient querying and containerized execution.
+- **Data Integrity**: Database-level constraints (CHECK, UNIQUE, FK) and Django validators to prevent invalid financial states.
+- **Security**: Password hashing, CSRF on state-changing requests, environment-based secrets (`.env` / platform config).
+- **Modularity**: Separate Django apps for wallet core, profiles, and reports with clear dependencies (`reports` reads `wallet` data; does not duplicate ledger writes).
+- **Performance**: Efficient ORM queries for history and reports; pagination where lists are large.
 
 ## **6. Phase Deliverables**
 
-- **PostgreSQL Schema**: Documented ERD and SQL migrations.
-- **FastAPI Backend**: Functional API with Pydantic validation.
-- **Technical Documentation**: Comprehensive guides for development, modules, and flows.
-- **Dockerized Environment**: Fully portable setup via `docker-compose`.
+- **PostgreSQL schema**: Documented in [DATABASE.md](DATABASE.md); Django migrations in-repo.
+- **Django application**: Wallet flows (Phase 3); profiles and reports (Phase 3.1).
+- **Technical documentation**: PRD, ARCHITECTURE, DATABASE, MODULES, FLOWS, ADRs.
+- **Dockerized environment** (Phase 4): Portable runtime via `Dockerfile` / `docker-compose` and CI.
 
 ---
 
-*Last updated: 16 February, 2026 - Phase 2 - Sprint 16: Database Design & Setup*
+*Last updated: 23 March, 2026 — Django-only product stack; Phase 3.1 requirements added.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,18 +2,19 @@
 
 This document outlines the strategic technical progression from a basic Frontend/Python prototype to a professional Full-Stack Enterprise Application. It serves as a guide for development, tooling, and infrastructure scaling.
 
+**Current product stack:** **Django** (MVT), **PostgreSQL**, server-rendered templates (Bootstrap 5 / jQuery). No separate FastAPI service in scope for the wallet product.
+
 ## Tech Stack
 
 | Category | Tool / Technology | Purpose | Implementation Phase |
 | --- | --- | --- | --- |
 | **Languages** | **HTML5 / CSS3** | Structure and responsive styling. | Phase 1 |
 |  | **JavaScript (ES6+)** | Client-side interactivity. | Phase 1 |
-|  | **Python 3.12+** | Backend logic and data processing. | Phase 1 - 4 |
-|  | **SQL** | Relational database querying. | Phase 2 - 3 |
+|  | **Python 3.12+** | Backend logic and data processing. | Phase 1 - 5 |
+|  | **SQL** | Relational database querying. | Phase 2 - 4 |
 | **Frameworks & Libraries** | **Bootstrap 5** | CSS Framework for responsive UI components. | Phase 1 |
 |  | **jQuery** | DOM manipulation and visual effects. | Phase 1 |
-|  | **Django** | High-level Python Web Framework (MVC/MVT). | Phase 3 |
-|  | **Pydantic** | Data validation and schema management using Python type hints. | Phase 2 |
+|  | **Django** | Web framework (MVT), ORM, auth, forms, admin. | Phase 3+ |
 | **Tooling & Quality (DX)** | **uv** | Blazing fast Python package and project manager (replaces `pip`/`venv`). | **All Phases** |
 |  | **Ruff** | Extremely fast Python linter and formatter (strict **PEP 8** compliance). | **All Phases** |
 |  | **Pytest** | Framework for scalable and simple unit/integration testing. | Phase 2 - 4 |
@@ -72,10 +73,34 @@ This document outlines the strategic technical progression from a basic Frontend
 
 ### Framework Integration
 
-* **MVC Architecture:** Port Python logic to **Django's MVT** (Model-View-Template) pattern.
-* **ORM Implementation:** Use Django ORM to interact with PostgreSQL, removing raw SQL queries.
-* **Authentication:** Implement Django's built-in Auth System for secure login and session management.
-* **Connectivity:** Connect existing HTML forms to Django Views.
+* **MVC Architecture:** **Django MVT** — views, templates, and URL routing.
+* **ORM Implementation:** Django ORM for PostgreSQL (models, constraints, migrations).
+* **Authentication:** Django’s built-in auth (login, sessions, password hashing).
+* **Connectivity:** HTML forms and class-based/function views for deposits, transfers, and history.
+
+---
+
+## 🟣 Phase 3.1: Profiles & Insights (next implementation)
+
+**Goal:** Extend the product with **`profiles`** and **`reports`** apps without changing core ledger rules in `wallet`.
+
+### `profiles` app
+
+* **`UserProfile`** model (`OneToOne` to `User`): editable display fields (e.g. first/last name or display name — align with forms), optional bio, **avatar** upload.
+* Views and templates for **view/edit profile**; validation and size/type limits for images.
+* Avatar storage strategy: see [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md) (local dev vs object storage in production).
+
+### `reports` app (insights)
+
+* **Read-only** aggregations over existing `wallet` data (no duplicate source of truth for balances).
+* UI: summaries by period, simple charts (as appropriate), filters consistent with history semantics.
+* **Export:** at minimum **CSV** download of the user’s scoped transaction set (or summary export — document in PRD when implemented).
+
+### Deliverables checklist
+
+* [ ] `profiles` registered in `INSTALLED_APPS`, migrations, URLs, templates.
+* [ ] `reports` registered, URLs, templates, tests for aggregation/export boundaries.
+* [ ] `MEDIA_ROOT` / `MEDIA_URL` configured for development; production path documented per ADR-04.
 
 ---
 
@@ -95,7 +120,24 @@ This document outlines the strategic technical progression from a basic Frontend
 
 * **Cloud Deployment:**
     * Configure automated deployment to **Render** or **Railway** connected to the GitHub repository.
+    * Align **static and media** configuration with ADR-04 for avatars where applicable.
 
-    ---
+---
 
-*Last updated: 16 February, 2026 - Phase 2 - Sprint 16: Database Design & Setup*
+## ⚪ Phase 5: Future improvements (post-MVP)
+
+**Goal:** Capture product ideas **not** scheduled for Phase 3.1. Scope here is indicative; each item may become its own app or module later.
+
+| Area | Indicative scope |
+| --- | --- |
+| **Preferences / settings** | Display currency, locale, date/number formatting; optional theme. |
+| **Notifications** | In-app and/or email for transfers, security events. |
+| **Support / help** | FAQ, contact form, lightweight tickets. |
+| **Security extras** | Session management UX, 2FA hooks, audit-friendly settings. |
+| **Budgets / categories** | Labels on transactions, monthly limits, spending views. |
+| **External accounts / cards** | Linked payment methods metadata (educational / non-PCI scope). |
+| **Formal statements** | Period “statement” PDFs or printable views (beyond ad-hoc CSV). |
+
+---
+
+*Last updated: 23 March, 2026 — Phase 3 complete; Phase 3.1 planned (`profiles`, `reports`).*

--- a/docs/adr/01-use-fastapi-for-backend-integration.md
+++ b/docs/adr/01-use-fastapi-for-backend-integration.md
@@ -1,7 +1,8 @@
 # ADR 01: Use FastAPI for Backend Integration
 
 ## Status
-Accepted
+
+**Superseded** — The shipping application uses **Django** as the sole server-side web framework from Phase 3 onward. This ADR remains a historical record of the Phase 1 backend choice. See [ARCHITECTURE.md](../ARCHITECTURE.md) for the current stack.
 
 ## Context
 In Phase 1 of the Proggy Wallet project, I needed to transition from standalone Python scripts to a connected web application. I required a backend framework that could bridge the gap between our Python logic (`auth.py`, `wallet.py`) and the jQuery-based frontend.

--- a/docs/adr/04-user-avatar-storage-local-vs-object-storage.md
+++ b/docs/adr/04-user-avatar-storage-local-vs-object-storage.md
@@ -1,0 +1,35 @@
+# ADR 04: User profile avatar storage (local filesystem vs object storage)
+
+## Status
+
+Accepted (strategy); **implementation choice is environment-dependent** (see Consequences).
+
+## Context
+
+Phase 3.1 introduces a `profiles` Django app with a `UserProfile` model that may include an **avatar** (`ImageField` or equivalent). Uploaded files must be stored somewhere served to browsers (`MEDIA_URL` / `MEDIA_ROOT` in Django).
+
+Constraints differ by environment:
+
+- **Local development:** A directory on disk under `MEDIA_ROOT` is simple and sufficient.
+- **Cloud deployment (Phase 4):** Many PaaS filesystems are **ephemeral**. New releases or restarts can **delete** files written only to local disk, breaking avatar URLs. Production therefore often needs **durable object storage** (e.g. S3, Cloudflare R2, GCS) or a **persistent volume** attached to the app.
+
+## Decision
+
+1. **Development:** Store avatars on the **local filesystem** via Django’s default `FileSystemStorage` and `MEDIA_ROOT` / `MEDIA_URL`.
+2. **Production:** Prefer **object storage** (S3-compatible API) using `django-storages` (or equivalent) **or** a platform-managed persistent disk, configured via environment variables. The exact provider (AWS S3, R2, etc.) is an implementation detail; the architectural rule is **durability and backup independent of the app container**.
+
+## Rationale
+
+- Keeps developer setup minimal while avoiding silent data loss in containerized production.
+- Avoids rewriting product docs on every hosting change: the **decision** is “local vs durable remote storage by environment,” not a single vendor name.
+
+## Consequences
+
+- **Positive:** Clear migration path from local dev to cloud without changing the `UserProfile` model’s field type in most cases (only `DEFAULT_FILE_STORAGE` / `STORAGES` settings change).
+- **Positive:** Aligns with Phase 4 checklist (secrets, `ALLOWED_HOSTS`, static/media strategy).
+- **Negative:** Production requires extra configuration (bucket, credentials, CORS if assets are served from a CDN domain).
+- **Neutral:** Optional image processing (resize, thumbnails) can be added later; out of scope for this ADR.
+
+---
+
+*Date: 23 March, 2026* | *Author: Aníbal Rojo*

--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -6,6 +6,7 @@ It is a living document that will be updated as the project evolves.
 ## 📑 Index
 
 ### 🏗️ Phase 3: Enterprise Ecosystem (Django)
+- [[2026-03-23] - Sprint 26: Documentation alignment and Phase 3.1 planning](#2026-03-23---sprint-26-documentation-alignment-and-phase-31-planning)
 - [[2026-03-11] - Sprint 25.5: Full-Layered Security and Integrity Implementation](#2026-03-11---sprint-255-full-layered-security-and-integrity-implementation)
 - [[2026-03-11] - Review: Data Integrity Layers in Django](#2026-03-11---review-data-integrity-layers-in-django)
 - [[2026-03-09] - Review: Service Layer Evolution & Django ORM Integration](#2026-03-09---review-service-layer-evolution--django-orm-integration)
@@ -52,6 +53,46 @@ It is a living document that will be updated as the project evolves.
 - [[2026-01-17] - Phase 1: Base utils & authentication modules](#2026-01-17---phase-1-base-utils--authentication-modules)
 - [[2026-01-16] - Phase 1: Initial project setup & tooling](#2026-01-16---phase-1-initial-project-setup--tooling)
 </details>
+
+---
+
+## [2026-03-23] - Sprint 26: Documentation alignment and Phase 3.1 planning
+
+### Context & Goals
+Now that the Phase 3 wallet functionality is in place, the **canonical docs** (`PRD`, `ARCHITECTURE`, `DATABASE`, `MODULES`, `FLOWS`, `CLASS_DIAGRAM`, `ROADMAP`) had drifted from the Django-only reality and did not yet describe the next product increment. 
+
+I decided to update  the documentation on **Django + PostgreSQL** (no FastAPI in the shipping product narrative), **recording** the historical FastAPI choice as superseded in **ADR-01**, and **locking in a concrete plan** for **Phase 3.1** (`profiles` with `UserProfile`, `reports`/insights) before the **Phase 4** implementation (deployment and CI/CD) plus a **Phase 5** backlog for post-MVP ideas.
+
+### Technical Implementation
+*   **`docs/ROADMAP.md`:** 
+     - Removed FastAPI/Pydantic from the forward-looking tech table. 
+     - Rewrote Phase 2 in generic OOP/PostgreSQL terms. 
+     - Added **Phase 3.1** (deliverables checklist for `profiles` and `reports`, `MEDIA_*`, CSV export intent) and **Phase 5** (future apps: preferences, notifications, support, budgets, etc.). 
+     - Kept **Phase 4** as CI/CD and cloud, with a pointer to avatar/media strategy for production.
+*   **`docs/PRD.md` & `docs/ARCHITECTURE.md`:** 
+     - Reframed the product around **Django MVT**, session-based flows, and planned apps. 
+     - Replaced the old FastAPI/service/repository stack diagram with a Django-oriented layer description. 
+     - Updated the ADR index to include **ADR-04** and mark **ADR-01** as **Superseded**.
+*   **`docs/DATABASE.md`:** 
+     - Extended the ERD with planned **`UserProfile`** (`OneToOne` to `User`).
+     - Documented that **`reports` v1** is expected to add **no new tables** (read-only over `wallet`).
+*   **`docs/MODULES.md` & `docs/FLOWS.md`:** 
+     - Added planned folder layout for `profiles/` and `reports/`. 
+     - Added dependency table (`reports` read-only on `wallet`). 
+     - Added illustrative future URL prefixes. 
+     - Added Mermaid flows for profile/avatar, insights, and CSV export.
+*   **`docs/CLASS_DIAGRAM.md`:** 
+     - Replaced Phase-2/Pydantic-centric narrative with **ORM-aligned** classes including planned **`UserProfile`**.
+*   **`docs/adr/04-user-avatar-storage-local-vs-object-storage.md`:** 
+     - New ADR — **local `MEDIA_ROOT` in development** vs **object storage or persistent volumes in production** to avoid silent file loss on ephemeral PaaS filesystems during Phase 4.
+
+### 💡 Deep Dive: Documentation as contract for the next slice of work
+Treating **docs as the contract** for Phase 3.1 reduces thrash when implementing `profiles` and `reports`: the **dependency rule** (reports never writes a parallel ledger) and **ADR-04** (where avatar bytes live per environment) are decided *before* the implementation, so settings and deployment checklists in Phase 4 stay traceable. Superseding **ADR-01** instead of deleting it preserves audit history while making the **current** stack unambiguous for readers.
+
+### Next Steps
+*   **Implement Phase 3.1:** Scaffold `profiles` (`UserProfile`, forms, templates, `MEDIA_URL` / `MEDIA_ROOT` in dev) and `reports` (aggregations, UI, user-scoped CSV export); register apps in `config/settings.py` and include URLconfs.
+*   **Phase 4:** `Dockerfile`, enhance the `docker-compose`, GitHub Actions (Ruff + Pytest), then cloud deploy with **media** configuration aligned to **ADR-04**.
+*   **Optional:** Pull items from **Phase 5** in `ROADMAP.md` into future sprints when scope is frozen per feature.
 
 ---
 


### PR DESCRIPTION
## Summary
Rebases project documentation on the **Django + PostgreSQL** stack (no FastAPI in the shipping product story), documents **Phase 3.1** (`profiles` / `UserProfile`, `reports`/insights) and **Phase 5** future backlog, and records avatar **media strategy** for dev vs production.

## Changes
- **ROADMAP / PRD / ARCHITECTURE** — Phase 3.1 checklist, Phase 5 table, MVT-oriented architecture; ADR index updated.
- **DATABASE / MODULES / FLOWS / CLASS_DIAGRAM** — Planned `UserProfile`, `profiles`/`reports` layout, illustrative URLs and planned Mermaid flows.
- **ADR-01** — Status **Superseded** (historical FastAPI decision).
- **ADR-04** — Local `MEDIA_*` vs object storage / persistent volume for avatars.
- **DEVLOG** — Sprint 26 entry (2026-03-23) summarizing the doc pass and next implementation steps.