### PR TITLE
feat(wallet): demo guest login with ephemeral sandbox users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,13 @@ DEBUG=True
 API_HOST=0.0.0.0
 API_PORT=8000
 
+# --- Demo guest sandbox (set DEMO_GUEST_PASSWORD in production / Render) ---
+# "Log in as a guest" creates guest + 3 peer users, then removes them from the DB on logout.
+# For local DB seeding / tests only: python manage.py ensure_demo_users
+# DEMO_GUEST_USERNAME=guest
+# DEMO_PEER_USERNAMES=demo_peer_1,demo_peer_2,demo_peer_3
+# DEMO_GUEST_PASSWORD=choose-a-strong-demo-password
+
 # --- RENDER CONFIGURATION ---
 # DJANGO_SETTINGS_MODULE=config.settings.production
 # SECRET_KEY=generate-a-new-one-for-production
@@ -24,3 +31,4 @@ API_PORT=8000
 # ALLOWED_HOSTS=your-app.onrender.com
 # DATABASE_URL=url-that-render-gives-you
 # PYTHON_VERSION=3.12.3
+# DEMO_GUEST_PASSWORD=same-value-as-above-for-guest-login

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,3 @@ python manage.py collectstatic --no-input
 
 # Apply migrations
 python manage.py migrate
-
-# Show migrations status (to verify DB health)
-python manage.py showmigrations

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "wallet",
+    "wallet.apps.WalletConfig",
     "profiles",
     "reports",
 ]
@@ -144,3 +144,16 @@ PASSWORD_HASHERS = [
 # Reference: ADR-04 for production strategy (Phase 4)
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
+
+# Demo / guest sandbox (isolated synthetic users; see wallet.demo_sandbox)
+DEMO_GUEST_USERNAME = env("DEMO_GUEST_USERNAME", default="guest")
+DEMO_PEER_USERNAMES = [
+    s.strip()
+    for s in env(
+        "DEMO_PEER_USERNAMES",
+        default="demo_peer_1,demo_peer_2,demo_peer_3",
+    ).split(",")
+    if s.strip()
+]
+# Set a strong value in production (Render env); default is for local dev only.
+DEMO_GUEST_PASSWORD = env("DEMO_GUEST_PASSWORD", default="guest-demo-dev")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,7 +1,8 @@
 # config/settings/production.py
 import dj_database_url
-from .base import *
 from decouple import config
+
+from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production
 DEBUG = False

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,0 +1,22 @@
+"""Settings for automated tests (SQLite in-memory, no Docker Postgres required)."""
+
+import os
+
+os.environ.setdefault("SECRET_KEY", "pytest-insecure-secret-key-not-for-production")
+
+from .base import *
+
+DEBUG = True
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "testserver"]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+SECURE_SSL_REDIRECT = False
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False

--- a/config/urls.py
+++ b/config/urls.py
@@ -25,6 +25,7 @@ from wallet import views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("accounts/guest-login/", views.guest_login, name="guest_login"),
     path("accounts/", include("django.contrib.auth.urls")),
     path("menu/", views.menu, name="menu"),
     path("deposit/", views.deposit, name="deposit"),

--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -6,6 +6,7 @@ It is a living document that will be updated as the project evolves.
 ## 📑 Index
 
 ### 🚀 Phase 4: Deployment & Infrastructure
+- [[2026-03-28] - Phase 4: Demo Guest Sandbox and Production DB Verification](#2026-03-28---phase-4-demo-guest-sandbox-and-production-db-verification)
 - [[2026-03-26] - Infrastructure: Cloud Deployment Config (Render & Supabase)](#2026-03-26---infrastructure-cloud-deployment-config-render--supabase)
 
 ### 🏗️ Phase 3: Enterprise Ecosystem (Django)
@@ -58,6 +59,33 @@ It is a living document that will be updated as the project evolves.
 - [[2026-01-17] - Phase 1: Base utils & authentication modules](#2026-01-17---phase-1-base-utils--authentication-modules)
 - [[2026-01-16] - Phase 1: Initial project setup & tooling](#2026-01-16---phase-1-initial-project-setup--tooling)
 </details>
+
+---
+
+## [2026-03-28] - Phase 4: Demo Guest Sandbox and Production DB Verification
+
+### Context & Goals
+Now that the app is deployed, a landing page was missing. I decided to make a **'log in as a guest'** button so visitors can explore the wallet with **pre-seeded data** without touching real user balances, while keeping production PostgreSQL (Supabase) **predictable** and **verifiable** from both the deployed app and external tooling (DBeaver). Also confirm end-to-end that **Render** uses the same database as **Supabase** when `DATABASE_URL` is configured correctly.
+
+### Technical Implementation
+- **Sandbox module (`wallet/demo_sandbox.py`):** Centralized demo logic: `ensure_demo_users_exist()` creates the configured `guest` and three `demo_peer_*` users; `reset_demo_sandbox()` deletes ledger rows for those users, resets `Account` balances, and inserts **10** canonical seed `Transaction` rows inside `transaction.atomic()`; `tear_down_demo_sandbox()` deletes sandbox transactions then removes demo `User` rows (CASCADE cleans related `Account` / profile rows). Helpers: `all_demo_usernames()`, `is_demo_guest_user`, `demo_peer_id_set`, strict `get_demo_peer_usernames()` (exactly three peers).
+- **Auth signals (`wallet/signals.py`):** On `user_logged_in`, if the user is the demo guest, call `reset_demo_sandbox()` so every guest session starts from the same snapshot. On `user_logged_out`, if the user is the guest, call `tear_down_demo_sandbox()` so demo users **do not persist** in the database between sessions.
+- **App wiring (`wallet/apps.py`):** `WalletConfig.ready()` imports `wallet.signals` so receivers register at startup.
+- **Guest entrypoint (`wallet/views.py`):** `guest_login` (`POST` only) calls `ensure_demo_users_exist()`, then `authenticate` / `login`, redirects to `menu`. `transfer` rejects transfers from real users to demo accounts (`is_demo_sandbox_username`) and keeps guest sends limited to peers (`demo_peer_id_set`).
+- **Forms (`wallet/forms.py`):** `TransferForm` restricts guest recipients to the three peers; non-guest users get a queryset that **excludes** all demo usernames so they never see demo accounts in the UI.
+- **URLs & UI:** `config/urls.py` registers `accounts/guest-login/` before `django.contrib.auth.urls`. `wallet/templates/registration/login.html` adds a second POST form for guest login and copy explaining teardown on logout.
+- **Deploy script (`build.sh`):** Removed automatic `ensure_demo_users` so production builds **do not** create demo rows; demo users appear only when someone uses guest login (or when running the management command locally).
+- **Management command (`wallet/management/commands/ensure_demo_users.py`):** Still available for **local / CI** to run `ensure_demo_users_exist()` + `reset_demo_sandbox()`.
+- **Tests & settings:** `wallet/test_demo_guest.py` with `config.settings.test` (SQLite); coverage for seed counts, transfer isolation, logout teardown, and non-demo transfer queryset. `.env.example` documents `DEMO_*` variables.
+- **Template polish (`wallet/templates/wallet/transactions.html`):** Avoid displaying `$None` when `balance_after` is null on incoming seed transfers.
+- **Operational verification:** Confirmed Render’s `DATABASE_URL` points at Supabase Postgres; **DBeaver** connected with the same connection parameters (host, port, database, user, password, SSL). Inspecting `wallet_transaction` (or equivalent) showed seed descriptions (e.g. “Opening deposit”, “Transfer to peer 1”), proving the deployed app writes to that database; after guest **logout**, teardown removes demo users and their sandbox rows when the signal runs successfully.
+
+### 💡 Deep Dive: Same database, scoped writes
+The app does **not** use a separate database for the demo. Integrity is enforced by **which users participate** (guest + three peers), **atomic reset** of their ledger, **transfer querysets** and view checks, and **teardown on logout** so demo rows are not left alongside real customers indefinitely. Observability (DBeaver) uses the same credentials as `DATABASE_URL`, so what you see in SQL is what Gunicorn on Render is using—modulo connection pooling host/port if you use Supabase’s pooler.
+
+### Next Steps
+- Optional: `DEMO_GUEST_ENABLED` (or similar) flag in production to hide guest login when the public demo should be off.
+- Document or automate cleanup for abandoned demo sessions (e.g. tab closed without logout) if stray rows become noisy.
 
 ---
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,7 +1,10 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import DetailView, UpdateView
+
+from wallet.demo_sandbox import is_demo_guest_user
 
 from .forms import ProfileForm
 from .models import UserProfile
@@ -27,6 +30,12 @@ class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     form_class = ProfileForm
     template_name = "profiles/profile_form.html"
     success_url = reverse_lazy("profiles:profile_detail")
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated and is_demo_guest_user(request.user):
+            messages.info(request, "Profile editing is disabled for the demo account.")
+            return redirect("profiles:profile_detail")
+        return super().dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):
         # Ensure the user only updates their own profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,14 @@ ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"config/settings/test.py" = ["F403"]
+"config/settings/local.py" = ["F403", "F405"]
+"config/settings/production.py" = ["F403", "F405"]
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 
 [tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "config.settings"
+DJANGO_SETTINGS_MODULE = "config.settings.test"
 python_files = ["tests.py", "test_*.py", "*_tests.py"]

--- a/wallet/apps.py
+++ b/wallet/apps.py
@@ -2,4 +2,8 @@ from django.apps import AppConfig
 
 
 class WalletConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "wallet"
+
+    def ready(self) -> None:
+        from wallet import signals  # noqa: F401

--- a/wallet/demo_sandbox.py
+++ b/wallet/demo_sandbox.py
@@ -1,0 +1,219 @@
+"""Reset demo guest + peer users to a fixed ledger snapshot (see management command)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.db import transaction as db_transaction
+from django.db.models import Q
+
+from wallet.models import Account, Transaction
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
+User = get_user_model()
+
+EXPECTED_PEER_COUNT = 3
+
+
+def all_demo_usernames() -> frozenset[str]:
+    return frozenset([settings.DEMO_GUEST_USERNAME, *get_demo_peer_usernames()])
+
+
+def is_demo_sandbox_username(username: str) -> bool:
+    return username in all_demo_usernames()
+
+
+def get_demo_peer_usernames() -> list[str]:
+    peers = list(settings.DEMO_PEER_USERNAMES)
+    if len(peers) != EXPECTED_PEER_COUNT:
+        msg = (
+            f"DEMO_PEER_USERNAMES must expand to exactly {EXPECTED_PEER_COUNT} usernames; "
+            f"got {len(peers)}: {peers!r}"
+        )
+        raise ValueError(msg)
+    return peers
+
+
+def ensure_demo_users_exist() -> None:
+    """Create guest + peer users and set passwords (no ledger seed). Idempotent."""
+    guest_name = settings.DEMO_GUEST_USERNAME
+    peer_names = get_demo_peer_usernames()
+    guest, _created_g = User.objects.get_or_create(
+        username=guest_name,
+        defaults={"email": f"{guest_name}@demo.local"},
+    )
+    guest.set_password(settings.DEMO_GUEST_PASSWORD)
+    guest.save()
+    for name in peer_names:
+        peer, _created = User.objects.get_or_create(
+            username=name,
+            defaults={"email": f"{name}@demo.local"},
+        )
+        peer.set_unusable_password()
+        peer.save()
+
+
+def tear_down_demo_sandbox() -> None:
+    """Remove all demo users and any transactions involving them (after guest logout)."""
+    users = list(User.objects.filter(username__in=all_demo_usernames()))
+    if not users:
+        return
+    ids = [u.id for u in users]
+    with db_transaction.atomic():
+        Transaction.objects.filter(
+            Q(from_user_id__in=ids) | Q(to_user_id__in=ids)
+        ).delete()
+        User.objects.filter(id__in=ids).delete()
+
+
+def sandbox_ledger_q(guest: User, peers: list[User]) -> Q:
+    ids = [guest.id] + [p.id for p in peers]
+    return Q(from_user_id__in=ids) | Q(to_user_id__in=ids)
+
+
+def reset_demo_sandbox() -> None:
+    """
+    Delete all transactions touching the guest or any demo peer, then re-seed
+    accounts and exactly 10 transactions. Idempotent.
+    """
+    guest_username = settings.DEMO_GUEST_USERNAME
+    peer_names = get_demo_peer_usernames()
+
+    guest = User.objects.filter(username=guest_username).first()
+    peers = list(User.objects.filter(username__in=peer_names).order_by("username"))
+    if guest is None or len(peers) != EXPECTED_PEER_COUNT:
+        missing = [guest_username] if guest is None else []
+        found_peer_names = {u.username for u in peers}
+        for name in peer_names:
+            if name not in found_peer_names:
+                missing.append(name)
+        raise ValueError(
+            "Demo sandbox users are missing; use Log in as a guest or run `python manage.py ensure_demo_users`. "
+            f"Missing: {missing}"
+        )
+
+    peer_by_name = {u.username: u for u in peers}
+    ordered_peers = [peer_by_name[name] for name in peer_names]
+
+    with db_transaction.atomic():
+        Transaction.objects.filter(sandbox_ledger_q(guest, peers)).delete()
+
+        balances: dict[int, Decimal] = {
+            guest.id: Decimal("0"),
+            ordered_peers[0].id: Decimal("0"),
+            ordered_peers[1].id: Decimal("0"),
+            ordered_peers[2].id: Decimal("0"),
+        }
+
+        p1, p2, p3 = ordered_peers
+
+        def refresh_accounts() -> None:
+            for uid, bal in balances.items():
+                Account.objects.filter(user_id=uid).update(balance=bal)
+
+        def create_tx(
+            *,
+            tx_type: str,
+            amount: Decimal,
+            from_u: User | None,
+            to_u: User | None,
+            description: str,
+            balance_after: Decimal | None,
+        ) -> None:
+            Transaction.objects.create(
+                from_user=from_u,
+                to_user=to_u,
+                amount=amount,
+                type=tx_type,
+                description=description,
+                balance_after=balance_after,
+            )
+
+        # 10 operations — end state: guest 50000, p1 1000, p2 1000, p3 3500
+        ops: list[tuple[str, dict[str, object]]] = [
+            ("deposit", {"to": guest, "amount": Decimal("10000"), "desc": "Opening deposit"}),
+            ("deposit", {"to": guest, "amount": Decimal("5000"), "desc": "Payroll top-up"}),
+            ("transfer", {"from": guest, "to": p1, "amount": Decimal("2000"), "desc": "Transfer to peer 1"}),
+            ("transfer", {"from": guest, "to": p2, "amount": Decimal("1500"), "desc": "Transfer to peer 2"}),
+            ("deposit", {"to": guest, "amount": Decimal("20000"), "desc": "Savings deposit"}),
+            ("transfer", {"from": guest, "to": p3, "amount": Decimal("3500"), "desc": "Transfer to peer 3"}),
+            ("transfer", {"from": p1, "to": guest, "amount": Decimal("1000"), "desc": "Refund from peer 1"}),
+            ("transfer", {"from": p2, "to": guest, "amount": Decimal("500"), "desc": "Refund from peer 2"}),
+            (
+                "withdrawal",
+                {"from": guest, "amount": Decimal("500"), "desc": "ATM withdrawal"},
+            ),
+            ("deposit", {"to": guest, "amount": Decimal("21000"), "desc": "Final demo deposit"}),
+        ]
+
+        for op_name, payload in ops:
+            if op_name == "deposit":
+                to_u = payload["to"]  # type: ignore[assignment]
+                amount = payload["amount"]  # type: ignore[assignment]
+                desc = payload["desc"]  # type: ignore[assignment]
+                assert isinstance(to_u, User)
+                balances[to_u.id] += amount
+                refresh_accounts()
+                create_tx(
+                    tx_type="deposit",
+                    amount=amount,
+                    from_u=None,
+                    to_u=to_u,
+                    description=str(desc),
+                    balance_after=balances[guest.id] if to_u.id == guest.id else None,
+                )
+            elif op_name == "transfer":
+                from_u = payload["from"]  # type: ignore[assignment]
+                to_u = payload["to"]  # type: ignore[assignment]
+                amount = payload["amount"]  # type: ignore[assignment]
+                desc = payload["desc"]  # type: ignore[assignment]
+                assert isinstance(from_u, User) and isinstance(to_u, User)
+                balances[from_u.id] -= amount
+                balances[to_u.id] += amount
+                refresh_accounts()
+                create_tx(
+                    tx_type="transfer",
+                    amount=amount,
+                    from_u=from_u,
+                    to_u=to_u,
+                    description=str(desc),
+                    balance_after=balances[guest.id]
+                    if guest.id in (from_u.id, to_u.id)
+                    else None,
+                )
+            elif op_name == "withdrawal":
+                from_u = payload["from"]  # type: ignore[assignment]
+                amount = payload["amount"]  # type: ignore[assignment]
+                desc = payload["desc"]  # type: ignore[assignment]
+                assert isinstance(from_u, User)
+                balances[from_u.id] -= amount
+                refresh_accounts()
+                create_tx(
+                    tx_type="withdrawal",
+                    amount=amount,
+                    from_u=from_u,
+                    to_u=None,
+                    description=str(desc),
+                    balance_after=balances[guest.id],
+                )
+
+        refresh_accounts()
+
+    seeded = Transaction.objects.filter(sandbox_ledger_q(guest, peers)).count()
+    if seeded != 10:
+        msg = f"Expected 10 sandbox transactions after seed, got {seeded}"
+        raise RuntimeError(msg)
+
+
+def is_demo_guest_user(user: User) -> bool:
+    return user.get_username() == settings.DEMO_GUEST_USERNAME
+
+
+def demo_peer_id_set() -> frozenset[int]:
+    names = get_demo_peer_usernames()
+    return frozenset(User.objects.filter(username__in=names).values_list("id", flat=True))

--- a/wallet/forms.py
+++ b/wallet/forms.py
@@ -1,7 +1,10 @@
 from decimal import Decimal
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
+
+from wallet.demo_sandbox import get_demo_peer_usernames, is_demo_guest_user
 
 
 class DepositForm(forms.Form):
@@ -29,8 +32,16 @@ class TransferForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         if self.user:
-            # Filter out the current user from the queryset
-            self.fields["to_user"].queryset = User.objects.exclude(id=self.user.id)
+            if is_demo_guest_user(self.user):
+                names = get_demo_peer_usernames()
+                self.fields["to_user"].queryset = User.objects.filter(username__in=names).order_by(
+                    "username"
+                )
+            else:
+                demo_names = [settings.DEMO_GUEST_USERNAME, *get_demo_peer_usernames()]
+                self.fields["to_user"].queryset = (
+                    User.objects.exclude(id=self.user.id).exclude(username__in=demo_names).order_by("username")
+                )
 
     def clean_amount(self):
         "Custom validation for the transfer amount"

--- a/wallet/forms.py
+++ b/wallet/forms.py
@@ -34,11 +34,13 @@ class TransferForm(forms.Form):
         if self.user:
             if is_demo_guest_user(self.user):
                 names = get_demo_peer_usernames()
+                # Only show the demo peer users to the demo guest user
                 self.fields["to_user"].queryset = User.objects.filter(username__in=names).order_by(
                     "username"
                 )
             else:
                 demo_names = [settings.DEMO_GUEST_USERNAME, *get_demo_peer_usernames()]
+                # Exclude the demo users from the recipient selection
                 self.fields["to_user"].queryset = (
                     User.objects.exclude(id=self.user.id).exclude(username__in=demo_names).order_by("username")
                 )

--- a/wallet/management/commands/ensure_demo_users.py
+++ b/wallet/management/commands/ensure_demo_users.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+from wallet.demo_sandbox import ensure_demo_users_exist, reset_demo_sandbox
+
+
+class Command(BaseCommand):
+    help = "Create demo guest + peer users if missing, then reset sandbox ledger (for local/testing)."
+
+    def handle(self, *args, **options) -> None:
+        try:
+            ensure_demo_users_exist()
+            reset_demo_sandbox()
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+        self.stdout.write(self.style.SUCCESS("Demo sandbox users ensured and ledger reset."))

--- a/wallet/signals.py
+++ b/wallet/signals.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+
+from django.contrib.auth.signals import user_logged_in, user_logged_out
+from django.dispatch import receiver
+
+from wallet.demo_sandbox import is_demo_guest_user, reset_demo_sandbox, tear_down_demo_sandbox
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(user_logged_in)
+def reset_demo_on_guest_login(sender, request, user, **kwargs) -> None:
+    if is_demo_guest_user(user):
+        try:
+            reset_demo_sandbox()
+        except Exception:
+            logger.exception("reset_demo_sandbox failed after guest login")
+
+
+@receiver(user_logged_out)
+def remove_demo_users_on_guest_logout(sender, request, user, **kwargs) -> None:
+    if user is not None and is_demo_guest_user(user):
+        try:
+            tear_down_demo_sandbox()
+        except Exception:
+            logger.exception("tear_down_demo_sandbox failed after guest logout")

--- a/wallet/templates/registration/login.html
+++ b/wallet/templates/registration/login.html
@@ -35,6 +35,18 @@
                         
                         <button type="submit" class="btn btn-primary w-100 btn-lg mt-3">Login</button>
                     </form>
+
+                    <hr class="my-4">
+
+                    <form method="post" action="{% url 'guest_login' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-outline-secondary w-100">
+                            Log in as a guest
+                        </button>
+                    </form>
+                    <p class="text-muted small text-center mt-2 mb-0">
+                        Demo accounts are created for your session and removed from the database when you log out.
+                    </p>
                 </div>
             </div>
         </div>

--- a/wallet/templates/wallet/transactions.html
+++ b/wallet/templates/wallet/transactions.html
@@ -48,7 +48,9 @@
                             <td class="{% if tx.from_user == user and tx.type != 'deposit' %}text-danger{% else %}text-success{% endif %}">
                                 {% if tx.from_user == user and tx.type != 'deposit' %}-{% else %}+{% endif %}${{ tx.amount }}
                             </td>
-                            <td class="fw-bold">${{ tx.balance_after }}</td> 
+                            <td class="fw-bold">
+                                {% if tx.balance_after is not None %}${{ tx.balance_after }}{% else %}—{% endif %}
+                            </td>
                         </tr>
                         {% empty %}
                         <!-- If there are no transactions, show a message -->

--- a/wallet/test_demo_guest.py
+++ b/wallet/test_demo_guest.py
@@ -1,0 +1,96 @@
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.db.models import Q
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+
+from wallet.demo_sandbox import sandbox_ledger_q
+from wallet.models import Account, Transaction
+
+
+@override_settings(
+    DEMO_GUEST_USERNAME="guest",
+    DEMO_PEER_USERNAMES=["demo_peer_1", "demo_peer_2", "demo_peer_3"],
+    DEMO_GUEST_PASSWORD="test-guest-password",
+)
+class DemoGuestSandboxTests(TestCase):
+    def setUp(self) -> None:
+        call_command("ensure_demo_users")
+
+    def _guest(self) -> User:
+        return User.objects.get(username="guest")
+
+    def _peers(self) -> list[User]:
+        return list(
+            User.objects.filter(username__in=["demo_peer_1", "demo_peer_2", "demo_peer_3"]).order_by("username")
+        )
+
+    def test_seed_balance_and_transaction_count(self) -> None:
+        guest = self._guest()
+        peers = self._peers()
+        self.assertEqual(len(peers), 3)
+        acc = Account.objects.get(user=guest)
+        self.assertEqual(acc.balance, Decimal("50000.00"))
+        qs = Transaction.objects.filter(sandbox_ledger_q(guest, peers))
+        self.assertEqual(qs.count(), 10)
+
+    def test_guest_transfer_form_only_lists_peers(self) -> None:
+        User.objects.create_user(username="regular_user", password="pw12345")
+        guest = self._guest()
+        from wallet.forms import TransferForm
+
+        form = TransferForm(user=guest)
+        qs = form.fields["to_user"].queryset
+        self.assertEqual(qs.count(), 3)
+        self.assertFalse(qs.filter(username="regular_user").exists())
+
+    def test_guest_transfer_post_rejects_non_peer_recipient(self) -> None:
+        regular = User.objects.create_user(username="regular_user", password="pw12345")
+        guest = self._guest()
+        client = Client()
+        client.force_login(guest)
+        before_count = Transaction.objects.filter(from_user=guest).count()
+        client.post(
+            reverse("transfer"),
+            {"to_user": str(regular.pk), "amount": "1.00"},
+        )
+        self.assertEqual(Transaction.objects.filter(from_user=guest).count(), before_count)
+        self.assertFalse(Transaction.objects.filter(from_user=guest, to_user=regular).exists())
+
+    def test_regular_user_transfer_form_excludes_demo_accounts(self) -> None:
+        User.objects.create_user(username="regular_user", password="pw12345")
+        regular = User.objects.get(username="regular_user")
+        from wallet.forms import TransferForm
+
+        form = TransferForm(user=regular)
+        usernames = set(form.fields["to_user"].queryset.values_list("username", flat=True))
+        self.assertNotIn("guest", usernames)
+        for name in ("demo_peer_1", "demo_peer_2", "demo_peer_3"):
+            self.assertNotIn(name, usernames)
+
+    def test_logout_removes_demo_users_from_database(self) -> None:
+        guest = self._guest()
+        peers = self._peers()
+        guest_pk = guest.pk
+        peer_pks = [p.pk for p in peers]
+        client = Client()
+        self.assertEqual(client.post(reverse("guest_login")).status_code, 302)
+        client.post(reverse("deposit"), {"amount": "25.00"}, follow=True)
+        self.assertTrue(User.objects.filter(username="guest").exists())
+
+        client.logout()
+
+        self.assertFalse(User.objects.filter(username="guest").exists())
+        self.assertEqual(
+            User.objects.filter(username__in=["demo_peer_1", "demo_peer_2", "demo_peer_3"]).count(),
+            0,
+        )
+        self.assertFalse(
+            Transaction.objects.filter(Q(from_user_id=guest_pk) | Q(to_user_id=guest_pk)).exists()
+        )
+        for pk in peer_pks:
+            self.assertFalse(
+                Transaction.objects.filter(Q(from_user_id=pk) | Q(to_user_id=pk)).exists()
+            )

--- a/wallet/tests.py
+++ b/wallet/tests.py
@@ -12,7 +12,9 @@ class WalletIntegrityTest(TestCase):
     def setUp(self):
         """Set up a test user and account."""
         self.user = User.objects.create_user(username="testuser", password="password123")
-        self.account = Account.objects.create(user=self.user, balance=Decimal("100.00"))
+        self.account = self.user.account
+        self.account.balance = Decimal("100.00")
+        self.account.save()
 
     def test_layer_5_model_validation_negative_balance(self):
         """Layer 5: Test that MinValueValidator prevents negative balance in Python."""

--- a/wallet/views.py
+++ b/wallet/views.py
@@ -1,13 +1,56 @@
+import logging
+
+from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import redirect, render
+from django.views.decorators.http import require_POST
 from django.views.generic import ListView
 
+from .demo_sandbox import (
+    demo_peer_id_set,
+    ensure_demo_users_exist,
+    is_demo_guest_user,
+    is_demo_sandbox_username,
+)
 from .forms import DepositForm, TransferForm
 from .models import Transaction
+
+logger = logging.getLogger(__name__)
+
+
+@require_POST
+def guest_login(request):
+    """Log in as the configured demo guest (credentials from settings / env)."""
+    username = settings.DEMO_GUEST_USERNAME
+    password = settings.DEMO_GUEST_PASSWORD
+
+    try:
+        ensure_demo_users_exist()
+    except Exception:
+        logger.exception("ensure_demo_users_exist failed during guest_login")
+        messages.error(request, "Demo login is not available.")
+        return redirect("login")
+
+    user = authenticate(request, username=username, password=password)
+    if user is None:
+        hint = (
+            " Check DEMO_GUEST_PASSWORD matches your environment."
+            if settings.DEBUG
+            else ""
+        )
+        messages.error(request, "Demo login is not available." + hint)
+        return redirect("login")
+    login(request, user)
+    messages.info(
+        request,
+        "You are using the demo guest account. Demo users are removed from the database when you log out.",
+    )
+    return redirect("menu")
 
 
 @login_required
@@ -56,6 +99,14 @@ def transfer(request):
         if form.is_valid():
             to_user = form.cleaned_data["to_user"]
             amount = form.cleaned_data["amount"]
+
+            if is_demo_guest_user(request.user) and to_user.id not in demo_peer_id_set():
+                messages.error(request, "Demo accounts can only transfer to demo peers.")
+                return render(request, "wallet/sendmoney.html", {"form": form})
+
+            if not is_demo_guest_user(request.user) and is_demo_sandbox_username(to_user.username):
+                messages.error(request, "You cannot transfer to demo accounts.")
+                return render(request, "wallet/sendmoney.html", {"form": form})
 
             try:
                 with transaction.atomic():


### PR DESCRIPTION
## Summary
Adds a **“Log in as a guest”** flow for demos (e.g. recruiters): pre-seeded ledger, transfers limited to three `demo_peer_*` users, and **removal of demo users + sandbox transactions on guest logout**. Real users no longer see demo accounts in the transfer recipient list.

## Key changes
- `wallet/demo_sandbox.py`: `ensure_demo_users_exist`, `reset_demo_sandbox` (10 seed transactions), `tear_down_demo_sandbox`
- `wallet/signals.py`: reset ledger on guest login; teardown on guest logout
- `guest_login` view + `accounts/guest-login/` route + login template button
- `TransferForm` + `transfer` view: guest ↔ peers only; block real → demo transfers
- `ensure_demo_users` management command for local/tests; **removed** from `build.sh` (no demo users created on deploy)
- Tests (`wallet/test_demo_guest.py`, `config.settings.test`), `.env.example` updates, transaction template `balance_after` display fix
- DEVLOG entry for guest sandbox + Render / Supabase / DBeaver verification notes

## How to test
1. `uv run python manage.py test wallet --settings=config.settings.test`
2. Locally: guest login → history shows 10 seed txs → logout → `guest` + peers gone from DB (or verify via DBeaver on shared Postgres)

## Env / deploy
Set `DEMO_GUEST_PASSWORD` (and optionally `DEMO_GUEST_USERNAME` / `DEMO_PEER_USERNAMES`) on Render. `DATABASE_URL` unchanged (Supabase).

Closes #83 