### PR TITLE
docs: Phase 3.1 documentation, DEVLOG, and Reports link from My Movements

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,10 +22,10 @@ The architecture follows a **classic Django web application** model: the browser
 * **Interface:** **Django** — URL routing, views (function- and class-based), Django Forms, Django ORM, and Django Templates.
 * **Technologies:** `Python 3.12+`, **Django**, **PostgreSQL**.
 
-### 2.3 Planned apps (Phase 3.1)
+### 2.3 Additional apps (Phase 3.1 — delivered)
 
-* **`profiles`:** `UserProfile` linked to `User`; profile edit and **avatar** uploads. Media storage strategy: [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
-* **`reports`:** Read-only **insights** over `wallet` models (aggregations, charts, CSV export). Does not introduce a second ledger; writes remain in `wallet`.
+* **`profiles`:** `UserProfile` linked to `User`; view at `/profile/me/`, edit at `/profile/me/edit/` with optional **avatar** uploads. Media storage strategy: [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+* **`reports`:** Read-only **insights** over `wallet` models at `/reports/dashboard/` (aggregations, Chart.js); **CSV** export at `/reports/export/` (user-scoped, same GET filters as the dashboard). No second ledger; writes remain in `wallet`.
 
 ## 3. Data Flow (Request / Response)
 
@@ -93,4 +93,4 @@ Dependencies point **inward**: URLconf → views → (forms / models) → ORM �
 
 ---
 
-*Last updated: 23 March, 2026 — Django architecture; Phase 3.1 apps documented.*
+*Last updated: 30 March, 2026 — Django architecture; Phase 3.1 `profiles` and `reports` shipped.*

--- a/docs/CLASS_DIAGRAM.md
+++ b/docs/CLASS_DIAGRAM.md
@@ -1,6 +1,6 @@
 # Class Diagram & Design Decisions
 
-This document describes the **domain-oriented** structure of Proggy Wallet aligned with the **Django** implementation (Phase 3) and the **planned** Phase 3.1 models. It complements [DATABASE.md](DATABASE.md) and `wallet/models.py`.
+This document describes the **domain-oriented** structure of Proggy Wallet aligned with the **Django** implementation (Phase 3 wallet core and Phase 3.1 `profiles`). It complements [DATABASE.md](DATABASE.md) and the apps’ `models.py` files.
 
 ## Class diagram (conceptual / ORM-aligned)
 
@@ -14,10 +14,12 @@ classDiagram
     }
 
     class UserProfile {
-        <<profiles Phase 3.1>>
+        <<profiles.UserProfile>>
         +OneToOne user
-        +avatar optional
         +bio optional
+        +avatar optional
+        +created_at
+        +updated_at
     }
 
     class Account {
@@ -44,7 +46,7 @@ classDiagram
     User "1" -- "*" Transaction : received_transactions
 ```
 
-**Phase 3.1 (reports):** Aggregation and export logic may live in plain Python functions or a small **`reports.services`** module; it is not a second ledger. Diagrams can add `<<service>>` helpers later if useful.
+**Reports (no ORM aggregate class):** Dashboard and CSV export use **`reports.services`** (filtered querysets, aggregates) and **`reports.views`**; they do **not** add models or a second ledger.
 
 ## Design decisions
 
@@ -58,9 +60,9 @@ classDiagram
 * **Decision:** `wallet.Transaction` records movements with optional `from_user` / `to_user` and positive `amount`.
 * **Rationale:** Audit trail and history UI; constraints at DB and model level prevent invalid amounts.
 
-### 3. UserProfile extension (Phase 3.1)
+### 3. UserProfile extension (Phase 3.1, shipped)
 
-* **Decision:** Separate **`UserProfile`** model with **`OneToOneField`** to `User` for display fields and avatar.
+* **Decision:** Separate **`UserProfile`** model with **`OneToOneField`** to `User` for `bio`, optional `avatar`, and timestamps.
 * **Rationale:** Avoid overriding Django’s `User` table; keeps auth upgrades straightforward. Avatar storage follows [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
 
 ### 4. Validation in Django, not a parallel API layer
@@ -75,4 +77,4 @@ classDiagram
 
 ---
 
-*Last updated: 23 March, 2026 — Django / Phase 3 + planned `UserProfile`.*
+*Last updated: 30 March, 2026 — Django Phase 3 + 3.1 (`UserProfile`, read-only reports layer).*

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,16 +2,16 @@
 
 This document serves as one of the three documents that makes up the single source of truth of this project, along with [ARCHITECTURE.md](ARCHITECTURE.md) and [PRD.md](PRD.md). Here its defined the *database* schema of the project, *where* and *how* the data is stored and how the entities interact with each other to accomplish the business logic defined in the PRD.
 
-The **implemented** wallet schema matches **Phase 3** (Django ORM): Django’s built-in user table plus `wallet_account` and `wallet_transaction` (see `wallet/models.py` and migrations).
+The **implemented** schema includes **Phase 3** (Django ORM): Django’s built-in user table plus `wallet_account` and `wallet_transaction` (see `wallet/models.py` and migrations), and **Phase 3.1** table **`profiles_userprofile`** for model **`UserProfile`** (see `profiles/models.py` and migrations).
 
-**Phase 3.1** adds **`profiles_userprofile`** (planned name: model **`UserProfile`**) as described below.
+The **`reports`** app adds **no tables** in v1 (read-only queries over `wallet`).
 
 ## Entity Relationship Diagram (ERD)
 
 ```mermaid
 erDiagram
     USER ||--|| ACCOUNT : "OneToOne"
-    USER ||--o| USERPROFILE : "OneToOne planned"
+    USER ||--o| USERPROFILE : "OneToOne"
     "TRANSACTION" }o--|| USER : "from_user"
     "TRANSACTION" }o--|| USER : "to_user"
 
@@ -25,8 +25,10 @@ erDiagram
     USERPROFILE {
         int id PK
         int user_id FK, UK
-        string avatar
+        string avatar "nullable"
         text bio
+        datetime created_at
+        datetime updated_at
     }
 
     ACCOUNT {
@@ -48,7 +50,7 @@ erDiagram
     }
 ```
 
-> **Note:** `USERPROFILE` is **planned** for Phase 3.1; exact optional columns (e.g. `display_name`) follow the `profiles` app implementation. The **`reports`** app is expected to add **no new tables** in the first iteration (read-only queries over `wallet`).
+> **Note:** `USERPROFILE` is **implemented** in `profiles`; the canonical column list is `profiles/models.py` and migrations. **`reports`** adds **no new tables** (read-only over `wallet`).
 
 ## Data Model Explanation
 
@@ -81,11 +83,12 @@ Append-only style ledger for deposits and transfers (and reserved type `withdraw
 - **created_at**: Automatic timestamp.
 - **balance_after**: Optional; after deposits/transfers from the web UI it stores the **sender’s** account balance after the operation where applicable.
 
-#### 4. UserProfile (`profiles.UserProfile`) — Phase 3.1 (planned)
+#### 4. UserProfile (`profiles.UserProfile`) — Phase 3.1 (implemented)
 
-- **user**: `OneToOneField` to `User` (primary association for extended profile data).
-- **avatar**: Optional image field; file storage per [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
-- Additional display or preference fields as required by the PRD and forms (migrations will be the canonical list).
+- **user**: `OneToOneField` to `User` (`related_name='profile'`). Cascade delete removes the profile with the user.
+- **bio**: `TextField`, optional (blank allowed), max length 500 at model level.
+- **avatar**: Optional `ImageField` (`upload_to='avatars/'`); file storage per [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+- **created_at** / **updated_at**: Automatic timestamps (`auto_now_add` / `auto_now`).
 
 ### Key Design Principles
 
@@ -95,4 +98,4 @@ Append-only style ledger for deposits and transfers (and reserved type `withdraw
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3 implemented; `UserProfile` planned Phase 3.1.*
+*Last updated: 30 March, 2026 — Phase 3.1 `UserProfile` implemented; `reports` remains table-free.*

--- a/docs/FLOWS.md
+++ b/docs/FLOWS.md
@@ -118,15 +118,17 @@ sequenceDiagram
     Browser->>User: Show paginated ledger
 ```
 
+From **My Movements**, the user may open **Reports** via a link to `GET /reports/dashboard/` (named route `reports:dashboard`).
+
 ## 5. Root URL
 
 `GET /` triggers a redirect to the named route **`menu`** (`/menu/`), implemented in `config/urls.py`.
 
 ---
 
-## 6. Planned flows — Phase 3.1 (`profiles`, `reports`)
+## 6. Phase 3.1 flows — `profiles` and `reports` (implemented)
 
-The following are **not yet implemented**; paths are illustrative (see [MODULES.md](MODULES.md)).
+Paths match [MODULES.md](MODULES.md) and `config/urls.py`.
 
 ### 6.1 View / edit profile and avatar
 
@@ -136,62 +138,84 @@ sequenceDiagram
     participant Browser
     participant View as profiles.views
     participant Form as ProfileForm
-    participant Storage as FileSystemStorage or S3
+    participant Storage as MediaStorage
     participant DB as PostgreSQL
 
-    User->>Browser: Open profile / edit form
-    Browser->>View: GET /profile/ (example path)
-    View->>DB: Load User + UserProfile
-    View-->>Browser: Render form
-    User->>Browser: Submit profile / optional image
-    Browser->>View: POST /profile/ (CSRF, multipart if file)
+    User->>Browser: Open profile or edit
+    Browser->>View: GET /profile/me/ or GET /profile/me/edit/
+    View->>View: LoginRequiredMixin
+    View->>DB: Load or create UserProfile for request.user
+    View-->>Browser: Render profile_detail or profile_form
+    User->>Browser: Submit profile optional image
+    Browser->>View: POST /profile/me/edit/ CSRF multipart if file
     View->>Form: is_valid()
     alt Valid
-        View->>DB: Save User fields + UserProfile
+        View->>DB: Save UserProfile
         opt Avatar present
-            View->>Storage: Save under MEDIA per ADR-04
+            View->>Storage: Save under MEDIA_ROOT per ADR-04
         end
-        View-->>Browser: Redirect + success message
+        View-->>Browser: Redirect to profile detail
     else Invalid
         View-->>Browser: Re-render with errors
     end
 ```
 
-### 6.2 Insights dashboard (read-only)
+### 6.2 Reports dashboard (read-only)
 
 ```mermaid
 sequenceDiagram
     participant User
     participant Browser
-    participant View as reports.views
+    participant View as reports.views.DashboardView
+    participant Form as ReportsFilterForm
+    participant Svc as reports.services
     participant ORM as Django ORM
     participant DB as PostgreSQL
 
-    User->>Browser: Open insights page
-    Browser->>View: GET /insights/ (example path)
+    User->>Browser: Open reports dashboard
+    Browser->>View: GET /reports/dashboard/?date_from=... optional
     View->>View: LoginRequiredMixin
-    View->>ORM: Aggregate/filter wallet.Transaction for request.user
-    ORM->>DB: SELECT (read-only)
-    DB-->>View: Rows / aggregates
-    View-->>Browser: Render reports template (charts/tables)
+    View->>Form: bind request.GET
+    alt Form valid
+        View->>Svc: summaries monthly rows type breakdown filtered user
+        Svc->>ORM: read only queries on Transaction
+        ORM->>DB: SELECT aggregates
+        DB-->>View: context for charts and KPIs
+        View-->>Browser: Render dashboard.html Chart.js payloads
+    else Form invalid
+        View-->>Browser: Re-render with errors unfiltered aggregates
+    end
 ```
 
 ### 6.3 CSV export (user-scoped)
 
+Same filter contract as the dashboard: query params `date_from`, `date_to`, `filter` (income or expense), `tx_type`. Invalid date range returns **400** with form errors (no CSV body). Empty result set returns **200** with header row only. Anonymous users are redirected to login.
+
 ```mermaid
 sequenceDiagram
     participant User
     participant Browser
-    participant View as reports.views
+    participant View as TransactionCsvExportView
+    participant Form as ReportsFilterForm
+    participant Svc as reports.services
     participant DB as PostgreSQL
 
-    User->>Browser: Request export (link or POST)
-    Browser->>View: GET export endpoint with same scope as UI filters
-    View->>View: LoginRequiredMixin, build queryset for current user only
-    View->>DB: Read transactions (or summary rows)
-    View-->>Browser: text/csv response (attachment)
+    User->>Browser: Apply filters optional click Export CSV
+    Browser->>View: GET /reports/export/? same params as dashboard form
+    View->>View: LoginRequiredMixin
+    View->>Form: bind request.GET
+    alt Form invalid
+        View-->>Browser: 400 Bad Request text plain
+    else Form valid
+        View->>Svc: get_filtered_transactions_for_user request.user
+        Svc->>DB: SELECT transactions read only
+        DB-->>View: rows
+        View-->>Browser: 200 text csv charset utf 8 attachment transactions_export.csv
+    end
 ```
+
+The dashboard **Export CSV** button submits the filter form with `formaction` pointing to `reports:export` so current field values are sent as GET parameters.
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3 implemented; Phase 3.1 planned.*
+*Last updated: 30 March, 2026 — Phase 3.1 flows implemented (profiles, reports, CSV).*

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,4 +1,4 @@
-# Module Architecture (Phase 3)
+# Module Architecture (Phase 3 + 3.1)
 
 This document describes the responsibilities and dependencies of the system modules in the Django-based architecture.
 
@@ -6,8 +6,8 @@ This document describes the responsibilities and dependencies of the system modu
 
 ```text
 proggy-wallet/
-├── config/               # Django project: settings, root URLconf, WSGI/ASGI
-│   ├── settings.py
+├── config/               # Django project: settings package, root URLconf, WSGI/ASGI
+│   ├── settings/         # base.py, local.py, production.py, test.py
 │   ├── urls.py
 │   ├── wsgi.py
 │   └── asgi.py
@@ -21,14 +21,14 @@ proggy-wallet/
 │   │       ├── menu.html
 │   │       ├── deposit.html
 │   │       ├── sendmoney.html   # served by URL name transfer → path transfer/
-│   │       └── transactions.html
+│   │       └── transactions.html  # My Movements; includes link to Reports dashboard
 │   ├── admin.py
 │   ├── apps.py
 │   ├── forms.py
 │   ├── models.py
 │   ├── tests.py
 │   └── views.py
-├── profiles/             # Phase 3.1 — UserProfile, avatar, edit profile (planned)
+├── profiles/             # Phase 3.1 — UserProfile, avatar, edit profile (shipped)
 │   ├── migrations/
 │   ├── templates/
 │   │   └── profiles/
@@ -37,16 +37,17 @@ proggy-wallet/
 │   ├── views.py
 │   ├── urls.py
 │   └── tests.py
-├── reports/              # Phase 3.1 — insights, charts, CSV export (planned)
-│   ├── migrations/       # Often empty at v1 (read-only from wallet)
+├── reports/              # Phase 3.1 — insights, charts, CSV export (shipped)
+│   ├── migrations/       # Empty at v1 (read-only from wallet)
 │   ├── templates/
 │   │   └── reports/
-│   ├── services.py       # Optional: aggregation helpers
-│   ├── views.py
+│   ├── services.py       # Aggregation and filter helpers (_filtered_user_transactions, etc.)
+│   ├── chart_payloads.py # JSON-safe chart data for Chart.js
+│   ├── forms.py          # ReportsFilterForm (dashboard + CSV query params)
+│   ├── views.py          # DashboardView, TransactionCsvExportView
 │   ├── urls.py
 │   └── tests.py
-├── templates/            # Optional project-level templates (e.g. index.html)
-├── static/               # STATICFILES_DIRS in settings (project static assets)
+├── static/               # STATICFILES_DIRS (e.g. js/reports_dashboard.js)
 ├── docs/
 ├── scripts/
 ├── .env
@@ -55,56 +56,64 @@ proggy-wallet/
 └── manage.py
 ```
 
-**Template loading:** `config/settings.py` sets `TEMPLATES['DIRS']` to `[]` and uses `APP_DIRS: True`, so app templates are resolved from each installed app’s `templates/` package (e.g. `wallet`, then `profiles`, `reports` once added).
+**Template loading:** `config/settings/base.py` sets `TEMPLATES['DIRS']` to `[]` and uses `APP_DIRS: True`, so app templates resolve from each installed app’s `templates/` package (`wallet`, `profiles`, `reports`).
 
-### App dependencies (Phase 3.1 target)
+### App dependencies
 
 | App | Depends on | Notes |
 | --- | --- | --- |
 | `wallet` | `django.contrib.auth` | Core ledger and accounts. |
-| `profiles` | `auth.User` | `UserProfile` one-to-one; media files via `MEDIA_*` settings. |
+| `profiles` | `auth.User` | `UserProfile` one-to-one; media files via `MEDIA_URL` / `MEDIA_ROOT`. |
 | `reports` | `wallet` (read-only) | Query `Transaction` / `Account`; no duplicate write path for money movement. |
 
 ## Wallet application (`wallet/`)
 
-- **`models.py`**: **(Data layer)** `Account`, `Transaction`, and `User` provisioning signal. Validators (**layer 5**) and `CheckConstraint` (**layer 6**) match `wallet/models.py`.
+- **`models.py`**: **(Data layer)** `Account`, `Transaction`, and `User` provisioning signal. Validators and `CheckConstraint` match the ORM.
 - **`views.py`**: **(Logic layer)** `menu`, `deposit`, `transfer` (function views), and `TransactionHistoryView` (class-based list with pagination and query filters). Uses `transaction.atomic()` for deposits and transfers.
 - **`forms.py`**: **(Validation layer)** `DepositForm`, `TransferForm` — server-side rules before writes.
 - **`admin.py`**: Admin registration for wallet models.
 - **`tests.py`**: Tests for wallet behaviour.
 
+## Profiles application (`profiles/`)
+
+- **`models.py`**: `UserProfile` (`OneToOne` to `User`): `bio`, optional `avatar`, timestamps.
+- **`views.py`**: `ProfileDetailView`, `ProfileUpdateView` (`LoginRequiredMixin`).
+- **`forms.py`**: `ProfileForm` for edit (including optional image).
+- **`urls.py`**: Included under `/profile/` (see URL map below).
+
+## Reports application (`reports/`)
+
+- **`services.py`**: User-scoped filtered querysets and aggregates; `get_filtered_transactions_for_user` feeds CSV export.
+- **`views.py`**: `DashboardView` (filters via GET + charts); `TransactionCsvExportView` (`text/csv` attachment).
+- **`forms.py`**: `ReportsFilterForm` — field names `date_from`, `date_to`, `filter` (flow), `tx_type`; shared by dashboard and export.
+- **`chart_payloads.py`**, **`templates/reports/dashboard.html`**, **`static/js/reports_dashboard.js`**: Chart.js integration.
+
 ## Global configuration (`config/`)
 
-- **`settings.py`**: Database (`DB_URL` via `django-environ`), `INSTALLED_APPS` (includes `wallet`; will include `profiles`, `reports`), middleware, `STATIC_URL` / `STATICFILES_DIRS`, **`MEDIA_URL` / `MEDIA_ROOT`** when avatars ship (Phase 3.1), auth redirects (`LOGIN_REDIRECT_URL = 'menu'`, `LOGOUT_REDIRECT_URL = 'login'`), custom `PASSWORD_HASHERS` list.
+- **`settings/`**: Database (`DB_URL` via `django-environ`), `INSTALLED_APPS` includes `wallet`, `profiles`, `reports`, middleware, static/media, auth redirects (`LOGIN_REDIRECT_URL = 'menu'`, `LOGOUT_REDIRECT_URL = 'login'`).
 - **`urls.py`**: Root routes (see below).
 
 ### URL map (root `config/urls.py`)
 
-| Path | View / handler |
-| --- | --- |
-| `admin/` | Django admin |
-| `accounts/` | `django.contrib.auth.urls` (login, logout, password reset, etc.) |
-| `menu/` | `wallet.views.menu` |
-| `deposit/` | `wallet.views.deposit` |
-| `transfer/` | `wallet.views.transfer` → template `wallet/sendmoney.html` |
-| `history/` | `wallet.views.TransactionHistoryView` → `wallet/transactions.html` |
-| `''` | Redirect to named route `menu` |
-
-### Planned URLs (Phase 3.1 — wire in `config/urls.py` when implemented)
-
-| Path (illustrative) | App | Purpose |
+| Path | Name / namespace | Purpose |
 | --- | --- | --- |
-| `profile/` or `profiles/` | `profiles` | View/edit `UserProfile`, avatar upload |
-| `insights/` or `reports/` | `reports` | Dashboard of aggregates / charts |
-| `reports/export.csv` (example) | `reports` | User-scoped CSV download |
-
-Exact path prefixes and names should match `profiles/urls.py` and `reports/urls.py` once created.
+| `admin/` | — | Django admin |
+| `accounts/` | — | `django.contrib.auth.urls` (login, logout, password reset) |
+| `menu/` | `menu` | Wallet menu after login |
+| `deposit/` | `deposit` | Deposit form |
+| `transfer/` | `transfer` | Transfer form → `sendmoney.html` |
+| `history/` | `history` | My Movements (`transactions.html`); **Reports** button → `reports:dashboard` |
+| `profile/me/` | `profiles:profile_detail` | View profile |
+| `profile/me/edit/` | `profiles:profile_edit` | Edit profile / avatar |
+| `reports/dashboard/` | `reports:dashboard` | Insights dashboard (filters, charts) |
+| `reports/export/` | `reports:export` | CSV download (same GET filter params as dashboard) |
+| `''` | `root_redirect` | Redirect to `menu` |
 
 ## Presentation layer
 
-- **DTL**: Bootstrap-oriented pages under `wallet/templates/`; login under `wallet/templates/registration/` for `auth` URLs.
-- **Static files**: Served from the project `static/` directory per `STATICFILES_DIRS`.
+- **DTL**: Bootstrap-oriented pages under app templates; login under `wallet/templates/registration/` for `auth` URLs.
+- **Static files**: Project `static/` per `STATICFILES_DIRS` (e.g. reports JS).
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3 shipped; Phase 3.1 (`profiles`, `reports`) planned structure.*
+*Last updated: 30 March, 2026 — Phase 3.1 shipped (`profiles`, `reports`, CSV export, navigation from My Movements to Reports).*

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -20,7 +20,7 @@ To develop a reference architecture for a digital wallet application. The primar
 |                    | **JavaScript / jQuery** | DOM manipulation and client-side logic. |
 | **Backend**        | **Python 3.12+ / Django** | Server-side logic, routing, ORM, forms, session auth, admin. |
 | **Database**       | **PostgreSQL** | Relational data persistence and integrity. |
-| **Quality (QA)**   | **Ruff / Pytest** | Strict linting and automated tests. |
+| **Quality (QA)**   | **Ruff**; **Django `TestCase`** via `manage.py test`; **Pytest** (optional, `pytest-django` in dev) | Linting, formatting, and automated tests. |
 | **Management**     | **uv** | High-performance dependency and project manager. |
 | **Validation**     | **Django Forms / ORM** | Server-side validation and model constraints. |
 | **Infrastructure** | **Docker** (Phase 4) | Containerization for consistent environments and deployment. |
@@ -34,24 +34,29 @@ To develop a reference architecture for a digital wallet application. The primar
 2. **Menu / dashboard**: Entry point after login; navigation to wallet actions.
 3. **Deposits**: Form to add funds with immediate persistence on the user’s `Account`.
 4. **Transfers**: Peer-to-peer transfers with balance validation and atomic updates.
-5. **History**: Transaction ledger scoped to the current user, with filtering and pagination.
+5. **History**: Transaction ledger scoped to the current user, with filtering and pagination; link from My Movements to the **Reports** dashboard.
 
 **B. Data and integrity**
 1. **Single source of truth** for balances on `Account`; immutable-style ledger on `Transaction` as implemented in Django.
 2. **Financial logic**: Atomic operations for transfers and deposits (database transaction boundaries).
 3. **Constraints**: Non-negative balances, strictly positive transaction amounts, enforced in ORM and DB where defined.
 
-### **4.2 Phase 3.1 — Profiles & insights (planned)**
+### **4.2 Phase 3.1 — Profiles & insights (delivered)**
 
 **A. `profiles` app**
-1. **UserProfile**: Extended data linked **one-to-one** to Django `User` (e.g. display-oriented fields, optional bio).
-2. **Avatar**: Optional profile image upload with documented limits (format/size); storage per [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
-3. **Edit flow**: Authenticated user can view and update their own profile (and avatar).
+1. **UserProfile**: Extended data linked **one-to-one** to Django `User` (`bio`, optional `avatar`, timestamps).
+2. **Avatar**: Optional profile image upload; storage per [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md).
+3. **Edit flow**: Authenticated user views `/profile/me/` and edits `/profile/me/edit/` (demo guest account may be restricted from editing).
 
 **B. `reports` app (insights)**
-1. **Summaries**: Aggregated views over the user’s wallet activity (e.g. by period, by movement type), using existing `wallet` models only (**read-only**).
-2. **Visualization**: Charts or summary cards as appropriate (implementation detail).
-3. **Export**: Minimum **CSV** export for a clearly defined user-scoped dataset (e.g. filtered transactions or summary table — exact export shape to be fixed in implementation and MODULES/FLOWS).
+1. **Summaries**: Aggregated views over the user’s wallet activity (period, flow, type), **read-only** over `wallet.Transaction` / `Account`.
+2. **Visualization**: Bootstrap layout, KPI cards, Chart.js bar and doughnut charts, filterable via GET (`/reports/dashboard/`).
+3. **Export — CSV contract (transaction rows)**  
+   - **Endpoint:** `GET /reports/export/` (authenticated); same query parameters as the dashboard filter form.  
+   - **Parameters:** `date_from`, `date_to` (optional dates); `filter` optional values `income`, `expense`; `tx_type` optional `deposit`, `transfer`, `withdrawal`. Invalid range (e.g. start after end) → **400** with plain-text form errors.  
+   - **Response:** `Content-Type: text/csv; charset=utf-8`; `Content-Disposition: attachment`; filename `transactions_export.csv`.  
+   - **Columns (header row, in order):** `id`, `created_at` (ISO 8601), `type`, `amount` (decimal string), `flow` (`income` / `expense` from the viewer’s perspective), `from_username`, `to_username`, `description`, `balance_after` (empty if null).  
+   - **Scope:** Only transactions involving the current user after filters; empty set → **200** with headers only.
 
 ### **4.3 Phase 5 — Out of current MVP**
 
@@ -73,4 +78,4 @@ Features listed under **Phase 5** in [ROADMAP.md](ROADMAP.md) (preferences, noti
 
 ---
 
-*Last updated: 23 March, 2026 — Django-only product stack; Phase 3.1 requirements added.*
+*Last updated: 30 March, 2026 — Phase 3.1 delivered; CSV contract and navigation documented.*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,27 +80,27 @@ This document outlines the strategic technical progression from a basic Frontend
 
 ---
 
-## 🟣 Phase 3.1: Profiles & Insights (next implementation)
+## 🟣 Phase 3.1: Profiles & Insights (delivered)
 
 **Goal:** Extend the product with **`profiles`** and **`reports`** apps without changing core ledger rules in `wallet`.
 
 ### `profiles` app
 
-* **`UserProfile`** model (`OneToOne` to `User`): editable display fields (e.g. first/last name or display name — align with forms), optional bio, **avatar** upload.
-* Views and templates for **view/edit profile**; validation and size/type limits for images.
+* **`UserProfile`** model (`OneToOne` to `User`): optional **bio**, optional **avatar**; timestamps.
+* Views and templates for **view/edit profile** (`/profile/me/`, `/profile/me/edit/`); image validation in forms.
 * Avatar storage strategy: see [ADR-04](adr/04-user-avatar-storage-local-vs-object-storage.md) (local dev vs object storage in production).
 
 ### `reports` app (insights)
 
 * **Read-only** aggregations over existing `wallet` data (no duplicate source of truth for balances).
-* UI: summaries by period, simple charts (as appropriate), filters consistent with history semantics.
-* **Export:** at minimum **CSV** download of the user’s scoped transaction set (or summary export — document in PRD when implemented).
+* UI: `/reports/dashboard/` — KPIs, monthly and type charts, GET filters aligned with history semantics; entry link from **My Movements** (`/history/`).
+* **Export:** `GET /reports/export/` — CSV of **filtered transactions** for the current user (columns and query parameters in [PRD.md](PRD.md) §4.2).
 
 ### Deliverables checklist
 
-* [ ] `profiles` registered in `INSTALLED_APPS`, migrations, URLs, templates.
-* [ ] `reports` registered, URLs, templates, tests for aggregation/export boundaries.
-* [ ] `MEDIA_ROOT` / `MEDIA_URL` configured for development; production path documented per ADR-04.
+* [x] `profiles` registered in `INSTALLED_APPS`, migrations, URLs, templates.
+* [x] `reports` registered, URLs, templates, tests for aggregation/export boundaries.
+* [x] `MEDIA_ROOT` / `MEDIA_URL` configured for development (`config/settings/base.py`); production path documented per ADR-04.
 
 ---
 
@@ -140,4 +140,4 @@ This document outlines the strategic technical progression from a basic Frontend
 
 ---
 
-*Last updated: 23 March, 2026 — Phase 3 complete; Phase 3.1 planned (`profiles`, `reports`).*
+*Last updated: 30 March, 2026 — Phase 3 complete; Phase 3.1 delivered (`profiles`, `reports`, CSV).*

--- a/docs/development/DEVELOPMENT_GUIDE.md
+++ b/docs/development/DEVELOPMENT_GUIDE.md
@@ -1,49 +1,108 @@
 # Development Guide
 
-This document contains instructions for setting up and working on the Proggy Wallet project.
+Instructions for setting up and working on the Proggy Wallet **Django** project.
 
-## Local Environment Setup
+## Local environment setup
 
 ### Prerequisites
-- **uv**: Python package and project manager.
-- **Docker Desktop**: For running the PostgreSQL database.
-- **WSL2**: (If on Windows) Ensure Docker integration is enabled for your distro.
 
-### Database Infrastructure
-We use PostgreSQL 18 via Docker Compose for local development.
+- **uv**: Python package and project manager.
+- **Docker Desktop** (or compatible engine): for PostgreSQL via Compose.
+- **WSL2** (if on Windows): ensure Docker integration works for your distro.
+
+### Database
+
+PostgreSQL runs via Docker Compose for local development.
 
 ```bash
 # Start the database in the background
-sudo docker compose up -d
+docker compose up -d
 
 # View database logs
-sudo docker logs proggy_wallet_db
+docker logs proggy_wallet_db
 
-# Stop the database and remove data (Reset)
-sudo docker compose down -v
+# Stop and remove containers and volumes (reset data)
+docker compose down -v
 ```
 
-### Python Development
-We use `uv` for dependency management and `ruff` for code quality.
+Ensure `.env` contains `DB_URL` (and `SECRET_KEY`) as expected by `config/settings/base.py`.
+
+### Python dependencies
 
 ```bash
-# Sync dependencies and create virtual environment
 uv sync
+```
 
-# Run the FastAPI development server
-uv run fastapi dev backend/app.py
+Default Django settings for `manage.py` are **`config.settings.local`** (see `manage.py`).
 
-# Run linter and formatter
+### Run the development server
+
+```bash
+uv run python manage.py runserver
+```
+
+Open the app (typically `http://127.0.0.1:8000/`). Root URL redirects to **`/menu/`** after configuration in `config/urls.py`.
+
+### Migrations
+
+```bash
+uv run python manage.py migrate
+```
+
+## Code quality
+
+```bash
+# Lint (PEP 8 and selected rules via Ruff)
 uv run ruff check .
+
+# Format
 uv run ruff format .
 ```
 
-### Testing
+To scope to one app: `uv run ruff check wallet/` (or `profiles/`, `reports/`).
+
+## Testing
+
+Primary workflow uses Django’s test runner (same discovery as in CI-friendly setups):
+
 ```bash
-# Run all unit tests
-uv run pytest
+# All discovered tests
+uv run python manage.py test
+
+# By app
+uv run python manage.py test wallet
+uv run python manage.py test profiles
+uv run python manage.py test reports
 ```
+
+Tests use **`config.settings.test`** when invoked through pytest; `manage.py` uses `local` unless you override:
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings.test uv run python manage.py test
+```
+
+Optional: **pytest** with **pytest-django** (configured in `pyproject.toml`):
+
+```bash
+uv run pytest
+uv run pytest reports/
+```
+
+If PostgreSQL raises prompts about an existing test database, use `--keepdb` after the first successful run:
+
+```bash
+uv run python manage.py test --keepdb
+```
+
+## Project layout (quick reference)
+
+- **`wallet/`** — ledger, menu, deposit, transfer, transaction history.
+- **`profiles/`** — `UserProfile`, `/profile/me/`, `/profile/me/edit/`.
+- **`reports/`** — `/reports/dashboard/`, `/reports/export/` (CSV).
+- **`docs/`** — PRD, architecture, MODULES, FLOWS, DATABASE, etc.
+
+Canonical routes are listed in [MODULES.md](../MODULES.md).
 
 ---
 
-*Last updated: 16 February, 2026 - Phase 2 - Sprint 16: Database Design & Setup*
+*Last updated: 30 March, 2026 — Django stack; uv, Ruff, `manage.py test`, and pytest.*

--- a/docs/development/DEVLOG.md
+++ b/docs/development/DEVLOG.md
@@ -10,6 +10,7 @@ It is a living document that will be updated as the project evolves.
 - [[2026-03-26] - Infrastructure: Cloud Deployment Config (Render & Supabase)](#2026-03-26---infrastructure-cloud-deployment-config-render--supabase)
 
 ### 🏗️ Phase 3: Enterprise Ecosystem (Django)
+- [[2026-03-30] - Phase 3.1: Reports CSV Export, Tests & Documentation](#2026-03-30---phase-31-reports-csv-export-tests--documentation)
 - [[2026-03-26] - Phase 3.1: Reports Dashboard & Visualization](#2026-03-26---phase-31-reports-dashboard--visualization)
 - [[2026-03-25] - Phase 3.1: User Profiles Infrastructure & Management](#2026-03-25---phase-31-user-profiles-infrastructure--management)
 - [[2026-03-23] - Sprint 26: Documentation alignment and Phase 3.1 planning](#2026-03-23---sprint-26-documentation-alignment-and-phase-31-planning)
@@ -59,6 +60,39 @@ It is a living document that will be updated as the project evolves.
 - [[2026-01-17] - Phase 1: Base utils & authentication modules](#2026-01-17---phase-1-base-utils--authentication-modules)
 - [[2026-01-16] - Phase 1: Initial project setup & tooling](#2026-01-16---phase-1-initial-project-setup--tooling)
 </details>
+
+---
+
+## [2026-03-30] - Phase 3.1: Reports CSV Export, Tests & Documentation
+
+### Context & Goals
+
+Close **`phase31-13`** (reports CSV export, automated tests, documentation alignment) so the insights workstream matches the canonical docs and the product contract: users can download a **user-scoped, filter-aligned** transaction CSV, the behaviour is covered by Django tests, and readers of PRD / MODULES / FLOWS see the real routes and export semantics—not a “planned” Phase 3.1 sketch. Also improve discoverability: the reports dashboard was only reachable by URL until this sprint.
+
+### Technical Implementation
+
+- **CSV export (`reports/views.py`):** 
+    - `TransactionCsvExportView` (`LoginRequiredMixin`, `GET`) validates `ReportsFilterForm` bound to `request.GET`; invalid filters (e.g. `date_from` > `date_to`) return `HttpResponseBadRequest` with form errors as plain text. 
+    - Success path streams rows via `csv.writer` with fixed columns (`id`, `created_at`, `type`, `amount`, `flow`, `from_username`, `to_username`, `description`, `balance_after`), `Content-Type: text/csv; charset=utf-8`, and `Content-Disposition: attachment` filename `transactions_export.csv`. 
+    - Empty queryset still returns a valid CSV with **header only**.
+- **Services (`reports/services.py`):** 
+    - `get_filtered_transactions_for_user` centralizes the same filter kwargs as the dashboard on top of `_filtered_user_transactions`, with `select_related("from_user", "to_user")` and stable ordering (`-created_at`, `-id`). 
+    - `transaction_flow_for_user` labels each row `income` / `expense` from the viewer’s perspective (self-transfer resolves to `expense` to match dashboard double-count semantics).
+- **Routing (`reports/urls.py`):** `export/` named `reports:export` under the existing `reports/` prefix.
+- **Dashboard UI (`reports/templates/reports/dashboard.html`):** **Export CSV** submit button uses `formaction` pointing to `reports:export` so current filter fields are submitted as GET parameters without requiring a separate “Apply” step.
+    - **Form binding fix (`reports/views.py`):** `DashboardView` and `TransactionCsvExportView` bind `ReportsFilterForm(self.request.GET)` / `ReportsFilterForm(request.GET)` instead of `request.GET or None`. An empty `QueryDict` is falsy in Python, so the old pattern left the form **unbound** and `is_valid()` was always false—breaking export with no query string (400 instead of header-only CSV). The dashboard now treats an empty GET as valid optional filters.
+- **Tests (`reports/tests.py`):** 
+    - `TransactionCsvExportViewTests` cover anonymous redirect, invalid dates (400), empty export (header only), isolation (user A never sees B–C-only transactions), `filter=expense` and `tx_type=deposit` scope, and row count parity with `get_filtered_transactions_for_user`. 
+    - `TransactionFlowForUserTests` cover deposit → `income`, outgoing transfer → `expense`, self-transfer → `expense`. 
+    - Helpers `EXPECTED_CSV_HEADER` and `_parse_csv_response` keep assertions readable.
+- **Navigation (`wallet/templates/wallet/transactions.html`):** 
+    - **Reports** button below the My Movements table links to `reports:dashboard`.
+- **Documentation (canonical set):** 
+    - Updated [MODULES.md](../MODULES.md), [FLOWS.md](../FLOWS.md), [PRD.md](../PRD.md), [ARCHITECTURE.md](../ARCHITECTURE.md), [DATABASE.md](../DATABASE.md), [CLASS_DIAGRAM.md](../CLASS_DIAGRAM.md), [ROADMAP.md](../ROADMAP.md), and [DEVELOPMENT_GUIDE.md](DEVELOPMENT_GUIDE.md). 
+
+### 💡 Deep Dive: One filter contract, two representations
+
+The dashboard and CSV export share **`ReportsFilterForm`** and the same GET parameter names (`date_from`, `date_to`, `filter`, `tx_type`). Aggregates on the page intentionally **count roles separately** for transfers (`get_user_financial_summary` transaction count), while the CSV emits **one row per transaction**; tests assert export row count against `get_filtered_transactions_for_user().count()`, not the summary counter, to avoid a subtle false failure. Keeping validation strict (400 on bad dates) avoids serving a misleading file when the user’s intent is ambiguous.
 
 ---
 
@@ -124,7 +158,7 @@ Close **`phase31-10`** (insights dashboard, filters, charts) by shipping a dedic
 Aggregations stay in the database: filtered querysets use `annotate`/`aggregate` so the app ships summaries, not full transaction lists. The view never hand-builds JSON strings for charts; it passes plain dicts into the template and uses the **`json_script`** filter so data is HTML-escaped and consumed as `textContent` in JavaScript—this avoids `mark_safe` and reduces XSS risk compared to embedding raw JSON in attributes. The static initializer stays thin: it only bridges DOM payloads to Chart.js configuration, keeping business rules and labeling on the Python side.
 
 ### Next Steps
-- **`phase31-13`:** CSV (or similar) export of the **currently filtered** report set, reusing the same service/query patterns.
+- **`phase31-13`:** Delivered 2026-03-30 — see [Phase 3.1: Reports CSV Export, Tests & Documentation](#2026-03-30---phase-31-reports-csv-export-tests--documentation).
 - Optional hardening: document or test edge cases for legacy rows where `from_user`/`to_user` might not match deposit semantics (see project notes on net flow vs historical data).
 - Keep `SPRINTS.md` / issue tracker in sync with shipped checklist items for this phase.
 

--- a/reports/services.py
+++ b/reports/services.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
-from django.db.models import Avg, Count, Q, Sum
+from django.contrib.auth.models import AbstractBaseUser
+from django.db.models import Avg, Count, Q, QuerySet, Sum
 from django.db.models.functions import TruncMonth
 from django.utils import timezone
 
@@ -26,6 +27,48 @@ def _filtered_user_transactions(user, *, date_from=None, date_to=None, flow_filt
     elif flow_filter == "expense":
         qs = qs.filter(from_user=user)
     return qs
+
+
+def get_filtered_transactions_for_user(
+    user,
+    *,
+    date_from=None,
+    date_to=None,
+    flow_filter: str | None = None,
+    tx_type: str | None = None,
+) -> QuerySet[Transaction]:
+    """
+    Transactions involving the user with the same filters as the reports dashboard.
+    Ordered for stable CSV export (newest first).
+    """
+    return (
+        _filtered_user_transactions(
+            user,
+            date_from=date_from,
+            date_to=date_to,
+            flow_filter=flow_filter,
+            tx_type=tx_type,
+        )
+        .select_related("from_user", "to_user")
+        .order_by("-created_at", "-id")
+    )
+
+
+def transaction_flow_for_user(tx: Transaction, user: AbstractBaseUser) -> str:
+    """
+    CSV flow label from the viewer's perspective: expense (out) vs income (in).
+    If the user is both sender and receiver, expense is reported (matches dashboard double-count semantics).
+    """
+    uid = user.pk
+    is_from = tx.from_user_id == uid
+    is_to = tx.to_user_id == uid
+    if is_from and is_to:
+        return "expense"
+    if is_from:
+        return "expense"
+    if is_to:
+        return "income"
+    return ""
 
 
 def get_user_financial_summary(user, *, date_from=None, date_to=None, flow_filter=None, tx_type=None):

--- a/reports/templates/reports/dashboard.html
+++ b/reports/templates/reports/dashboard.html
@@ -30,6 +30,11 @@
                 <div class="col-12 col-md-2">
                     <button type="submit" class="btn btn-primary w-100">Apply</button>
                 </div>
+                <div class="col-12 col-md-2">
+                    <button type="submit" formaction="{% url 'reports:export' %}" class="btn btn-outline-secondary w-100">
+                        Export CSV
+                    </button>
+                </div>
             </div>
         </form>
         {% if filter_form.errors %}

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -1,3 +1,5 @@
+import csv
+import io
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
@@ -213,3 +215,208 @@ class DashboardViewTests(TestCase):
         response = self.client.get(reverse("reports:dashboard"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="chart-types"')
+
+
+EXPECTED_CSV_HEADER = [
+    "id",
+    "created_at",
+    "type",
+    "amount",
+    "flow",
+    "from_username",
+    "to_username",
+    "description",
+    "balance_after",
+]
+
+
+def _parse_csv_response(response):
+    text = response.content.decode("utf-8")
+    rows = list(csv.reader(io.StringIO(text)))
+    return rows[0], rows[1:]
+
+
+class TransactionCsvExportViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="csvuser", password="secret123")
+        Account.objects.filter(user=self.user).update(balance=Decimal("1000.00"))
+
+    def test_export_redirects_when_anonymous(self):
+        response = self.client.get(reverse("reports:export"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login", response.url)
+
+    def test_export_invalid_date_range_returns_400(self):
+        self.client.login(username="csvuser", password="secret123")
+        response = self.client.get(
+            reverse("reports:export"),
+            {"date_from": "2025-06-10", "date_to": "2025-06-01"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"date", response.content.lower())
+
+    def test_export_empty_transactions_header_only(self):
+        self.client.login(username="csvuser", password="secret123")
+        response = self.client.get(reverse("reports:export"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/csv", response["Content-Type"])
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertIn("transactions_export.csv", response["Content-Disposition"])
+        header, data_rows = _parse_csv_response(response)
+        self.assertEqual(header, EXPECTED_CSV_HEADER)
+        self.assertEqual(len(data_rows), 0)
+
+    def test_export_user_isolation_excludes_other_users_transactions(self):
+        user_b = User.objects.create_user(username="csvuser_b", password="x")
+        user_c = User.objects.create_user(username="csvuser_c", password="x")
+        Account.objects.filter(user=user_b).update(balance=Decimal("500.00"))
+        Account.objects.filter(user=user_c).update(balance=Decimal("500.00"))
+
+        tx_a = Transaction.objects.create(
+            to_user=self.user,
+            amount=Decimal("25.00"),
+            type="deposit",
+            balance_after=Decimal("25.00"),
+        )
+        tx_bc = Transaction.objects.create(
+            from_user=user_b,
+            to_user=user_c,
+            amount=Decimal("99.00"),
+            type="transfer",
+            balance_after=Decimal("1.00"),
+        )
+
+        self.client.login(username="csvuser", password="secret123")
+        response = self.client.get(reverse("reports:export"))
+        self.assertEqual(response.status_code, 200)
+        _, data_rows = _parse_csv_response(response)
+        ids_exported = {int(row[0]) for row in data_rows}
+        self.assertIn(tx_a.id, ids_exported)
+        self.assertNotIn(tx_bc.id, ids_exported)
+
+    def test_export_expense_filter_matches_service_queryset(self):
+        other = User.objects.create_user(username="csvpeer", password="x")
+        Account.objects.filter(user=other).update(balance=Decimal("100.00"))
+        Transaction.objects.create(
+            to_user=self.user,
+            amount=Decimal("100.00"),
+            type="deposit",
+            balance_after=Decimal("100.00"),
+        )
+        Transaction.objects.create(
+            from_user=self.user,
+            to_user=other,
+            amount=Decimal("40.00"),
+            type="transfer",
+            balance_after=Decimal("60.00"),
+        )
+
+        kw = {"flow_filter": "expense"}
+        expected_count = services.get_filtered_transactions_for_user(self.user, **kw).count()
+        self.assertEqual(expected_count, 1)
+
+        self.client.login(username="csvuser", password="secret123")
+        response = self.client.get(reverse("reports:export"), {"filter": "expense"})
+        self.assertEqual(response.status_code, 200)
+        _, data_rows = _parse_csv_response(response)
+        self.assertEqual(len(data_rows), expected_count)
+        self.assertEqual(data_rows[0][2], "transfer")
+        self.assertEqual(data_rows[0][4], "expense")
+
+    def test_export_tx_type_deposit_only(self):
+        other = User.objects.create_user(username="csvpeer2", password="x")
+        Account.objects.filter(user=other).update(balance=Decimal("100.00"))
+        Transaction.objects.create(
+            to_user=self.user,
+            amount=Decimal("10.00"),
+            type="deposit",
+            balance_after=Decimal("10.00"),
+        )
+        Transaction.objects.create(
+            from_user=self.user,
+            to_user=other,
+            amount=Decimal("5.00"),
+            type="transfer",
+            balance_after=Decimal("5.00"),
+        )
+
+        kw = {"tx_type": "deposit"}
+        expected_count = services.get_filtered_transactions_for_user(self.user, **kw).count()
+
+        self.client.login(username="csvuser", password="secret123")
+        response = self.client.get(reverse("reports:export"), {"tx_type": "deposit"})
+        self.assertEqual(response.status_code, 200)
+        _, data_rows = _parse_csv_response(response)
+        self.assertEqual(len(data_rows), expected_count)
+        self.assertEqual(len(data_rows), 1)
+        self.assertEqual(data_rows[0][2], "deposit")
+
+    def test_export_row_count_matches_queryset_with_multiple_transactions(self):
+        other = User.objects.create_user(username="csvpeer3", password="x")
+        Account.objects.filter(user=other).update(balance=Decimal("200.00"))
+        Transaction.objects.create(
+            to_user=self.user,
+            amount=Decimal("1.00"),
+            type="deposit",
+            balance_after=Decimal("1.00"),
+        )
+        Transaction.objects.create(
+            to_user=self.user,
+            amount=Decimal("2.00"),
+            type="deposit",
+            balance_after=Decimal("3.00"),
+        )
+        Transaction.objects.create(
+            from_user=self.user,
+            to_user=other,
+            amount=Decimal("0.50"),
+            type="transfer",
+            balance_after=Decimal("2.50"),
+        )
+
+        expected_count = services.get_filtered_transactions_for_user(self.user).count()
+        self.assertEqual(expected_count, 3)
+
+        self.client.login(username="csvuser", password="secret123")
+        response = self.client.get(reverse("reports:export"))
+        self.assertEqual(response.status_code, 200)
+        _, data_rows = _parse_csv_response(response)
+        self.assertEqual(len(data_rows), expected_count)
+
+
+class TransactionFlowForUserTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="flowuser", password="x")
+        Account.objects.filter(user=self.user).update(balance=Decimal("1000.00"))
+        self.other = User.objects.create_user(username="flowother", password="x")
+        Account.objects.filter(user=self.other).update(balance=Decimal("100.00"))
+
+    def test_deposit_to_user_is_income(self):
+        tx = Transaction.objects.create(
+            to_user=self.user,
+            amount=Decimal("50.00"),
+            type="deposit",
+            balance_after=Decimal("50.00"),
+        )
+        self.assertEqual(services.transaction_flow_for_user(tx, self.user), "income")
+
+    def test_transfer_sent_is_expense(self):
+        tx = Transaction.objects.create(
+            from_user=self.user,
+            to_user=self.other,
+            amount=Decimal("10.00"),
+            type="transfer",
+            balance_after=Decimal("90.00"),
+        )
+        self.assertEqual(services.transaction_flow_for_user(tx, self.user), "expense")
+
+    def test_self_transfer_reports_expense(self):
+        tx = Transaction.objects.create(
+            from_user=self.user,
+            to_user=self.user,
+            amount=Decimal("1.00"),
+            type="transfer",
+            balance_after=Decimal("99.00"),
+        )
+        self.assertEqual(services.transaction_flow_for_user(tx, self.user), "expense")

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -6,4 +6,5 @@ app_name = "reports"
 
 urlpatterns = [
     path("dashboard/", views.DashboardView.as_view(), name="dashboard"),
+    path("export/", views.TransactionCsvExportView.as_view(), name="export"),
 ]

--- a/reports/views.py
+++ b/reports/views.py
@@ -18,7 +18,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        form = ReportsFilterForm(self.request.GET or None)
+        form = ReportsFilterForm(self.request.GET)
         user = self.request.user
 
         context["user_has_transactions"] = Transaction.objects.filter(Q(from_user=user) | Q(to_user=user)).exists()
@@ -69,7 +69,7 @@ class TransactionCsvExportView(LoginRequiredMixin, View):
     """User-scoped CSV download; query params match ReportsFilterForm / dashboard."""
 
     def get(self, request, *args, **kwargs):
-        form = ReportsFilterForm(request.GET or None)
+        form = ReportsFilterForm(request.GET)
         if not form.is_valid():
             return HttpResponseBadRequest(form.errors.as_text() or "Invalid filters.")
 

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,5 +1,10 @@
+import csv
+import io
+
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.views import View
 from django.views.generic import TemplateView
 
 from wallet.models import Transaction
@@ -58,3 +63,56 @@ class DashboardView(LoginRequiredMixin, TemplateView):
 
         context["filter_form"] = form
         return context
+
+
+class TransactionCsvExportView(LoginRequiredMixin, View):
+    """User-scoped CSV download; query params match ReportsFilterForm / dashboard."""
+
+    def get(self, request, *args, **kwargs):
+        form = ReportsFilterForm(request.GET or None)
+        if not form.is_valid():
+            return HttpResponseBadRequest(form.errors.as_text() or "Invalid filters.")
+
+        user = request.user
+        data = form.cleaned_data
+        kw = {
+            "date_from": data.get("date_from"),
+            "date_to": data.get("date_to"),
+            "flow_filter": data.get("filter") or None,
+            "tx_type": data.get("tx_type") or None,
+        }
+        qs = services.get_filtered_transactions_for_user(user, **kw)
+
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(
+            [
+                "id",
+                "created_at",
+                "type",
+                "amount",
+                "flow",
+                "from_username",
+                "to_username",
+                "description",
+                "balance_after",
+            ]
+        )
+        for tx in qs.iterator(chunk_size=500):
+            writer.writerow(
+                [
+                    tx.id,
+                    tx.created_at.isoformat(),
+                    tx.type,
+                    str(tx.amount),
+                    services.transaction_flow_for_user(tx, user),
+                    tx.from_user.username if tx.from_user_id else "",
+                    tx.to_user.username if tx.to_user_id else "",
+                    tx.description or "",
+                    str(tx.balance_after) if tx.balance_after is not None else "",
+                ]
+            )
+
+        response = HttpResponse(buffer.getvalue(), content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = 'attachment; filename="transactions_export.csv"'
+        return response

--- a/wallet/templates/wallet/transactions.html
+++ b/wallet/templates/wallet/transactions.html
@@ -106,5 +106,11 @@
         </div>
         {% endif %}
     </div>
+
+    <div class="text-center mt-4">
+        <a href="{% url 'reports:dashboard' %}" class="btn btn-outline-secondary">
+            <i class="bi bi-bar-chart-line me-1"></i> Reports
+        </a>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Align canonical docs with shipped `profiles` / `reports` (routes, CSV export contract, `UserProfile` in DATABASE/CLASS_DIAGRAM).
- Rewrite `DEVELOPMENT_GUIDE.md` for Django (`manage.py`, Ruff, tests).
- Add DEVLOG entry for the CSV export + documentation sprint (`phase31-13`).
- Add a **Reports** button on My Movements (`/history/`) pointing to `reports:dashboard`.

## Test plan
- [ ] `uv run python manage.py test wallet reports` (or full suite)
- [ ] Spot-check: open `/history/`, click Reports; open `/reports/dashboard/` and export CSV

## Related
- Closes #71 